### PR TITLE
Restore an accidentally omitted specialization that broke the HTTP over Unix domain sockets functionality.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,7 @@ SRCS=\
      resource.cc \
      oauth2.cc \
      logging.cc \
+     local_stream_http.cc \
      local_stream_delegate.cc \
      json.cc \
      time.cc \

--- a/src/asio/local_resolve_op.hpp
+++ b/src/asio/local_resolve_op.hpp
@@ -30,6 +30,7 @@
 #include <boost/asio/detail/handler_invoke_helpers.hpp>
 #include <boost/asio/detail/operation.hpp>
 #include <boost/asio/detail/socket_ops.hpp>
+#include <boost/asio/detail/resolve_op.hpp>
 #include <boost/network/uri.hpp>
 #include <sys/stat.h>
 

--- a/src/asio/local_resolver_service.hpp
+++ b/src/asio/local_resolver_service.hpp
@@ -28,6 +28,7 @@
 #include <boost/asio/detail/resolve_endpoint_op.hpp>
 #include <boost/asio/detail/resolve_op.hpp>
 #include <boost/asio/detail/resolver_service_base.hpp>
+#include <boost/asio/detail/resolver_service.hpp>
 #include <boost/asio/detail/socket_ops.hpp>
 #include <boost/network/uri.hpp>
 #include <sys/stat.h>

--- a/src/docker.cc
+++ b/src/docker.cc
@@ -16,11 +16,11 @@
 
 #include "docker.h"
 
+#include "local_stream_http.h"
 #include <boost/network/protocol/http/client.hpp>
 #include <chrono>
 
 #include "json.h"
-#include "local_stream_http.h"
 #include "logging.h"
 #include "resource.h"
 #include "time.h"

--- a/src/http/local_async_connection_base.hpp
+++ b/src/http/local_async_connection_base.hpp
@@ -1,30 +1,41 @@
-#ifndef BOOST_NETWORK_PROTOCOL_HTTP_IMPL_ASYNC_CONNECTION_BASE_20100529
-#define BOOST_NETWORK_PROTOCOL_HTTP_IMPL_ASYNC_CONNECTION_BASE_20100529
+#ifndef BOOST_NETWORK_PROTOCOL_HTTP_IMPL_LOCAL_ASYNC_CONNECTION_BASE_20170307
+#define BOOST_NETWORK_PROTOCOL_HTTP_IMPL_LOCAL_ASYNC_CONNECTION_BASE_20170307
 
-// Copryight 2013 Google, Inc.
+// Copyright 2017 Igor Peshansky (igorp@google.com).
+// Copyright 2013-2017 Google, Inc.
 // Copyright 2010 Dean Michael Berris <dberris@google.com>
 // Copyright 2010 (C) Sinefunc, Inc.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/network/traits/string.hpp>
 #include <boost/network/protocol/http/response.hpp>
-#include <boost/network/protocol/http/client/connection/connection_delegate_factory.hpp>
 #include <boost/network/protocol/http/traits/delegate_factory.hpp>
-#include <boost/network/protocol/http/client/connection/async_normal.hpp>
+#include "traits/local_resolver.hpp"
+#include <boost/network/protocol/http/traits/resolver_policy.hpp>
 
 namespace boost {
 namespace network {
 namespace http {
 namespace impl {
 
-template <class Tag, unsigned version_major, unsigned version_minor>
-struct async_connection_base {
+template<class Tag, unsigned int version_major, unsigned int version_minor>
+struct async_connection_base;
+
+template<class Tag, unsigned int version_major, unsigned int version_minor>
+struct http_async_connection;
+
+#define Tag tags::http_async_8bit_local_resolve
+#define version_major 1
+#define version_minor 1
+
+template<> struct async_connection_base<Tag, version_major, version_minor> {
   typedef async_connection_base<Tag, version_major, version_minor> this_type;
-  typedef typename resolver_policy<Tag>::type resolver_base;
-  typedef typename resolver_base::resolver_type resolver_type;
-  typedef typename resolver_base::resolve_function resolve_function;
-  typedef typename string<Tag>::type string_type;
+  typedef resolver_policy<Tag>::type resolver_base;
+  typedef resolver_base::resolver_type resolver_type;
+  typedef resolver_base::resolve_function resolve_function;
+  typedef string<Tag>::type string_type;
   typedef basic_request<Tag> request;
   typedef basic_response<Tag> response;
   typedef iterator_range<char const *> char_const_range;
@@ -45,20 +56,7 @@ struct async_connection_base {
       optional<string_type> certificate_file = optional<string_type>(),
       optional<string_type> private_key_file = optional<string_type>(),
       optional<string_type> ciphers = optional<string_type>(),
-      long ssl_options = 0) {
-    typedef http_async_connection<Tag, version_major, version_minor>
-        async_connection;
-    typedef typename delegate_factory<Tag>::type delegate_factory_type;
-    connection_ptr temp;
-    temp.reset(new async_connection(
-        resolver, resolve, follow_redirect, timeout,
-        delegate_factory_type::new_connection_delegate(
-            resolver.get_io_service(), https, always_verify_peer,
-            certificate_filename, verify_path, certificate_file,
-            private_key_file, ciphers, ssl_options)));
-    BOOST_ASSERT(temp.get() != 0);
-    return temp;
-  }
+      long ssl_options = 0);
 
   // This is the pure virtual entry-point for all asynchronous
   // connections.
@@ -69,6 +67,10 @@ struct async_connection_base {
   virtual ~async_connection_base() {}
 };
 
+#undef version_minor
+#undef version_major
+#undef Tag
+
 }  // namespace impl
 
 }  // namespace http
@@ -77,4 +79,4 @@ struct async_connection_base {
 
 }  // namespace boost
 
-#endif  // BOOST_NETWORK_PROTOCOL_HTTP_IMPL_ASYNC_CONNECTION_BASE_20100529
+#endif  // BOOST_NETWORK_PROTOCOL_HTTP_IMPL_LOCAL_ASYNC_CONNECTION_BASE_20170307

--- a/src/http/local_async_connection_base.ipp
+++ b/src/http/local_async_connection_base.ipp
@@ -1,0 +1,62 @@
+#ifndef BOOST_NETWORK_PROTOCOL_HTTP_IMPL_LOCAL_ASYNC_CONNECTION_BASE_IPP_20170307
+#define BOOST_NETWORK_PROTOCOL_HTTP_IMPL_LOCAL_ASYNC_CONNECTION_BASE_IPP_20170307
+
+// Copyright 2017 Igor Peshansky (igorp@google.com).
+// Copryight 2013-2017 Google, Inc.
+// Copyright 2010 Dean Michael Berris <dberris@google.com>
+// Copyright 2010 (C) Sinefunc, Inc.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/network/protocol/http/traits/delegate_factory.hpp>
+#include "local_async_normal.hpp"
+#include "local_async_connection_base.hpp"
+
+namespace boost {
+namespace network {
+namespace http {
+namespace impl {
+
+#define Tag tags::http_async_8bit_local_resolve
+#define version_major 1
+#define version_minor 1
+
+using acb = async_connection_base<Tag, version_major, version_minor>;
+
+acb::connection_ptr acb::new_connection(
+    acb::resolve_function resolve, acb::resolver_type &resolver,
+    bool follow_redirect, bool always_verify_peer, bool https, int timeout,
+    optional<acb::string_type> certificate_filename,
+    optional<acb::string_type> const &verify_path,
+    optional<acb::string_type> certificate_file,
+    optional<acb::string_type> private_key_file,
+    optional<acb::string_type> ciphers,
+    long ssl_options) {
+  typedef http_async_connection<Tag, version_major, version_minor>
+      async_connection;
+  typedef typename delegate_factory<Tag>::type delegate_factory_type;
+  connection_ptr temp;
+  temp.reset(new async_connection(
+      resolver, resolve, follow_redirect, timeout,
+      delegate_factory_type::new_connection_delegate(
+          resolver.get_io_service(), https, always_verify_peer,
+          certificate_filename, verify_path, certificate_file,
+          private_key_file, ciphers, ssl_options)));
+  BOOST_ASSERT(temp.get() != 0);
+  return temp;
+}
+
+#undef version_minor
+#undef version_major
+#undef Tag
+
+}  // namespace impl
+
+}  // namespace http
+
+}  // namespace network
+
+}  // namespace boost
+
+#endif  // BOOST_NETWORK_PROTOCOL_HTTP_IMPL_LOCAL_ASYNC_CONNECTION_BASE_IPP_20170307

--- a/src/http/local_async_normal.hpp
+++ b/src/http/local_async_normal.hpp
@@ -10,43 +10,26 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/network/version.hpp>
-#include <boost/network/detail/debug.hpp>
-#include <boost/thread/future.hpp>
-#include <boost/throw_exception.hpp>
-#include <boost/cstdint.hpp>
-#include <boost/range/algorithm/transform.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/network/constants.hpp>
-#include <boost/network/traits/ostream_iterator.hpp>
-#include <boost/network/traits/istream.hpp>
-#include <boost/logic/tribool.hpp>
-#include <boost/network/protocol/http/parser/incremental.hpp>
-#include <boost/network/protocol/http/message/wrappers/uri.hpp>
-#include <boost/network/protocol/http/client/connection/async_protocol_handler.hpp>
-#include <boost/network/protocol/http/algorithms/linearize.hpp>
-#include <boost/array.hpp>
-#include <boost/assert.hpp>
-#include <boost/bind/protect.hpp>
-#include <iterator>
-
-#include "../asio/local_resolver_service.hpp"
-#include "traits/local_resolver.hpp"
 #include "local_normal_delegate.hpp"
 #include "local_connection_delegate_factory.hpp"
-#include "local_tags.hpp"
+#include "../asio/local_resolve_op.hpp"
+#include "../asio/local_resolver_service.hpp"
+#include "local_async_connection_base.hpp"
+// Needed by async_protocol_handler.
+#include <boost/network/protocol/http/request.hpp>
+#include <boost/logic/tribool.hpp>
+#include <boost/network/protocol/http/parser/incremental.hpp>
+#include <boost/network/protocol/http/client/connection/async_protocol_handler.hpp>
 
 #include "../logging.h"
-
-#include <boost/network/protocol/http/traits/delegate_factory.hpp>
 
 namespace boost {
 namespace network {
 namespace http {
 namespace impl {
 
-template <class Tag, unsigned version_major, unsigned version_minor>
-struct async_connection_base;
+template<class Tag, unsigned int version_major, unsigned int version_minor>
+struct http_async_connection;
 
 namespace placeholders = boost::asio::placeholders;
 

--- a/src/http/local_connection_delegate_factory.hpp
+++ b/src/http/local_connection_delegate_factory.hpp
@@ -8,6 +8,8 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/optional.hpp>
+#include <boost/network/traits/string.hpp>
 #include "local_connection_delegate.hpp"
 #include "local_normal_delegate.hpp"
 #include "local_tags.hpp"
@@ -17,13 +19,14 @@ namespace network {
 namespace http {
 namespace impl {
 
+template<class Tag> struct connection_delegate_factory;
 struct local_normal_delegate;
 
 #define Tag tags::http_async_8bit_local_resolve
 
 template<> struct connection_delegate_factory<Tag> {
   typedef std::shared_ptr<local_connection_delegate> connection_delegate_ptr;
-  typedef typename string<Tag>::type string_type;
+  typedef string<Tag>::type string_type;
 
   // This is the factory method that actually returns the delegate
   // instance.

--- a/src/local_stream_http.cc
+++ b/src/local_stream_http.cc
@@ -1,0 +1,7 @@
+// Copyright 2017 Igor Peshansky (igorp@google.com).
+// Copyright 2017 Google, Inc.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "http/local_async_connection_base.ipp"


### PR DESCRIPTION
This is a follow-on to #14, and follows the same pattern — the specialized code is a verbatim copy of the original with only the specialized bits changed.