### PR TITLE
Use ENTRYPOINT instead of CMD in Dockerfile

### DIFF
--- a/pkg/docker/Dockerfile-trusty
+++ b/pkg/docker/Dockerfile-trusty
@@ -9,6 +9,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /stackdriver-metadata.deb
 
-CMD /opt/stackdriver/metadata/sbin/metadatad
+ENTRYPOINT ["/opt/stackdriver/metadata/sbin/metadatad"]
 
 EXPOSE 8000

--- a/pkg/docker/Dockerfile-xenial
+++ b/pkg/docker/Dockerfile-xenial
@@ -10,6 +10,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /stackdriver-metadata.deb
 
-CMD /opt/stackdriver/metadata/sbin/metadatad
+ENTRYPOINT ["/opt/stackdriver/metadata/sbin/metadatad"]
 
 EXPOSE 8000


### PR DESCRIPTION
This makes it easier to add command-line flags using 'args' in configs, such as Kubernetes YAML files.