### PR TITLE
Add the full instance monitored resource to associations

### DIFF
--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -127,6 +127,9 @@ class KubernetesReader {
   json::value FindTopLevelOwner(const std::string& ns, json::value object) const
       throw(QueryException, json::Exception);
 
+  // Gets the monitored resource of the instance the agent is running on.
+  json::value InstanceResource() const;
+
   // Cached data.
   mutable std::recursive_mutex mutex_;
   mutable std::string current_node_;


### PR DESCRIPTION
As `"infrastructureInstance"`. Replaces `"providerPlatform"`.