### PR TITLE
Base64 unit tests

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -22,7 +22,7 @@ namespace base64 {
 
 std::string Encode(const std::string &source);
 
-//std::string Decode(const std::string &source);
+std::string Decode(const std::string &source);
 
 }
 

--- a/src/base64.h
+++ b/src/base64.h
@@ -22,7 +22,7 @@ namespace base64 {
 
 std::string Encode(const std::string &source);
 
-std::string Decode(const std::string &source);
+//std::string Decode(const std::string &source);
 
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,7 @@ TEST_DIR=.
 TEST_SOURCES=$(wildcard $(TEST_DIR)/*_unittest.cc)
 TEST_OBJS=$(TEST_SOURCES:$(TEST_DIR)/%.cc=%.o)
 TESTS=\
-      format_unittest\
+      format_unittest \
       base64_unittest
 
 GTEST_LIB=gtest_lib.a

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,8 @@ TEST_DIR=.
 TEST_SOURCES=$(wildcard $(TEST_DIR)/*_unittest.cc)
 TEST_OBJS=$(TEST_SOURCES:$(TEST_DIR)/%.cc=%.o)
 TESTS=\
-      format_unittest
+      format_unittest\
+      base64_unittest
 
 GTEST_LIB=gtest_lib.a
 
@@ -62,6 +63,8 @@ $(GTEST_LIB): gtest-all.o gtest_main.o
 	$(AR) $(ARFLAGS) $@ $^
 
 format_unittest: $(GTEST_LIB) format_unittest.o $(SRC_DIR)/format.o
+	$(CXX) $(LDFLAGS) $^ $(LDLIBS) -o $@
+base64_unittest: $(GTEST_LIB) base64_unittest.o $(SRC_DIR)/base64.o
 	$(CXX) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 .PHONY: all test clean purge

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -1,0 +1,38 @@
+#include "../src/base64.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(EncodeTest, EmptyEncode) {
+  const std::string empty_str("");
+  EXPECT_EQ(
+      "",
+      base64::Encode(empty_str)
+  );
+}
+
+TEST(EncodeTest, SimpleEncode) {
+  const std::string simple_str("tes");
+  EXPECT_EQ(
+      "dGVz",
+      base64::Encode(simple_str)
+  );
+}
+
+TEST(EncodeTest, NoPaddingEncode) {
+  const std::string simple_str("test0");
+  EXPECT_EQ(
+      "dGVzdDA",
+      base64::Encode(simple_str)
+  );
+}
+
+TEST(EncodeTest, NoDoublePaddingEncode) {
+  const std::string simple_str("test");
+  EXPECT_EQ(
+      "dGVzdA",
+      base64::Encode(simple_str)
+  );
+}
+
+} // namespace

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -33,4 +33,16 @@ TEST(EncodeTest, NoDoublePaddingEncode) {
   );
 }
 
+TEST(RoundTripTest, FullString) {
+  EXPECT_EQ("tes", base64::Decode(base64::Encode("tes")));
+}
+
+TEST(RoundTripTest, OnePhantom) {
+  EXPECT_EQ("test0", base64::Decode(base64::Encode("test0")));
+}
+
+TEST(RoundTripTest, TwoPhantoms) {
+  EXPECT_EQ("test", base64::Decode(base64::Encode("test")));
+}
+
 } // namespace

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -12,7 +12,7 @@ TEST(EncodeTest, SimpleEncode) {
 }
 
 // Base64 encoders typically pad messages to ensure output length % 4 == 0. To
-// acheive this, encoders will pad messages with either one or two "=". Our
+// achieve this, encoders will pad messages with either one or two "=". Our
 // implementation does not do this. The following two tests ensure that
 // base64::Encode does not append one or two "=".
 TEST(EncodeTest, OnePhantom) {

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -4,34 +4,32 @@
 namespace {
 
 TEST(EncodeTest, EmptyEncode) {
-  const std::string empty_str("");
   EXPECT_EQ(
       "",
-      base64::Encode(empty_str)
+      base64::Encode("")
   );
 }
 
 TEST(EncodeTest, SimpleEncode) {
-  const std::string simple_str("tes");
   EXPECT_EQ(
       "dGVz",
-      base64::Encode(simple_str)
+      base64::Encode("tes")
   );
 }
 
+//Base64 encodings typically pad messages to ensure output length % 4 == 0, our
+//implementation does not
 TEST(EncodeTest, NoPaddingEncode) {
-  const std::string simple_str("test0");
   EXPECT_EQ(
       "dGVzdDA",
-      base64::Encode(simple_str)
+      base64::Encode("test0")
   );
 }
 
 TEST(EncodeTest, NoDoublePaddingEncode) {
-  const std::string simple_str("test");
   EXPECT_EQ(
       "dGVzdA",
-      base64::Encode(simple_str)
+      base64::Encode("test")
   );
 }
 

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -12,8 +12,8 @@ TEST(EncodeTest, SimpleEncode) {
 }
 
 // Base64 encoders typically pad messages to ensure output length % 4 == 0. To
-// acheive this, encoders will pad messages with either one or two "=".  Our
-// implementation does not do this.  The following two tests ensure that
+// acheive this, encoders will pad messages with either one or two "=". Our
+// implementation does not do this. The following two tests ensure that
 // base64::Encode does not append one or two "=".
 TEST(EncodeTest, OnePhantom) {
   EXPECT_EQ("dGVzdDA", base64::Encode("test0"));
@@ -58,5 +58,4 @@ TEST(RoundTripTest, OnePhantom) {
 TEST(RoundTripTest, TwoPhantoms) {
   EXPECT_EQ("test", base64::Decode(base64::Encode("test")));
 }
-
 } // namespace

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -4,33 +4,23 @@
 namespace {
 
 TEST(EncodeTest, EmptyEncode) {
-  EXPECT_EQ(
-      "",
-      base64::Encode("")
-  );
+  EXPECT_EQ("", base64::Encode(""));
 }
 
 TEST(EncodeTest, SimpleEncode) {
-  EXPECT_EQ(
-      "dGVz",
-      base64::Encode("tes")
-  );
+  EXPECT_EQ("dGVz", base64::Encode("tes"));
 }
 
-//Base64 encodings typically pad messages to ensure output length % 4 == 0, our
-//implementation does not
-TEST(EncodeTest, NoPaddingEncode) {
-  EXPECT_EQ(
-      "dGVzdDA",
-      base64::Encode("test0")
-  );
+// Base64 encoders typically pad messages to ensure output length % 4 == 0. To
+// acheive this, encoders will pad messages with either one or two "=".  Our
+// implementation does not do this.  The following two tests ensure that
+// base64::Encode does not append one or two "=".
+TEST(EncodeTest, OnePhantom) {
+  EXPECT_EQ("dGVzdDA", base64::Encode("test0"));
 }
 
-TEST(EncodeTest, NoDoublePaddingEncode) {
-  EXPECT_EQ(
-      "dGVzdA",
-      base64::Encode("test")
-  );
+TEST(EncodeTest, TwoPhantom) {
+  EXPECT_EQ("dGVzdA", base64::Encode("test"));
 }
 
 TEST(RoundTripTest, FullString) {

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -23,6 +23,30 @@ TEST(EncodeTest, TwoPhantom) {
   EXPECT_EQ("dGVzdA", base64::Encode("test"));
 }
 
+TEST(DecodeTest, EmptyDecode) {
+  EXPECT_EQ("", base64::Decode(""));
+}
+
+TEST(DecodeTest, SimpleDecode) {
+  EXPECT_EQ("tes", base64::Decode("dGVz"));
+}
+
+TEST(DecodeTest, OnePadding) {
+  EXPECT_EQ("test0", base64::Decode("dGVzdDA="));
+}
+
+TEST(DecodeTest, OnePhantom) {
+  EXPECT_EQ("test0", base64::Decode("dGVzdDA"));
+}
+
+TEST(DecodeTest, TwoPadding) {
+  EXPECT_EQ("test", base64::Decode("dGVzdA=="));
+}
+
+TEST(DecodeTest, TwoPhantom) {
+  EXPECT_EQ("test", base64::Decode("dGVzdA"));
+}
+
 TEST(RoundTripTest, FullString) {
   EXPECT_EQ("tes", base64::Decode(base64::Encode("tes")));
 }


### PR DESCRIPTION
Add testing for base64 encoding.  Remove base64 decoding from header file to reflect its commented out implementation.