### PR TITLE
Turn off throw() warnings in GCC 7+.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,10 @@ SUBMODULE_DIRS=$(CPP_NETLIB_DIR) $(YAML_CPP_DIR)
 
 SED_I=/usr/bin/env sed -i
 CMAKE=cmake
-CXXFLAGS=-std=c++11 -g -DENABLE_DOCKER_METADATA -DENABLE_KUBERNETES_METADATA -I$(CPP_NETLIB_DIR) -I$(YAML_CPP_DIR)/include
+CXXFLAGS=\
+    -std=c++11 -g -Wno-deprecated \
+    -DENABLE_DOCKER_METADATA -DENABLE_KUBERNETES_METADATA \
+    -I$(CPP_NETLIB_DIR) -I$(YAML_CPP_DIR)/include
 LDFLAGS=-L$(CPP_NETLIB_LIBDIR) -L$(YAML_CPP_LIBDIR)
 LDLIBS=-lcppnetlib-uri -lcppnetlib-client-connections -lboost_program_options \
     -lboost_system -lboost_thread -lpthread -lyajl -lssl -lcrypto -lyaml-cpp


### PR DESCRIPTION
GCC 7+ complains loudly about the `throw(...)` declarations.