### PR TITLE
Set headers when writing responses to properly return status code.

### DIFF
--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -47,7 +47,12 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
       if (config_.VerboseLogging()) {
         LOG(INFO) << "Found resource for " << id << ": " << resource;
       }
+      std::map<std::string, std::string> headers = {
+        {"Content-Type", "application/json"},
+      };
+
       conn->set_status(HttpServer::connection::ok);
+      conn->set_headers(headers);
       conn->write(resource.ToJSON()->ToString());
     } catch (const std::out_of_range& e) {
       // TODO: This could be considered log spam.
@@ -56,7 +61,11 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
       if (config_.VerboseLogging()) {
         LOG(WARNING) << "No matching resource for " << id;
       }
+      std::map<std::string, std::string> headers = {
+        {"Content-Type", "text/plain"},
+      };
       conn->set_status(HttpServer::connection::not_found);
+      conn->set_headers(headers);
     }
   }
 }

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -63,6 +63,11 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
       conn->set_headers(std::map<std::string, std::string>({
         {"Content-Type", "text/plain"},
       }));
+      json::value json_response = json::object({
+        {"status_code", json::int(404)},
+        {"error", json::string("Not found")},
+      });
+      conn->write(json_response->ToString());
     }
   }
 }

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -61,7 +61,7 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
       }
       conn->set_status(HttpServer::connection::not_found);
       conn->set_headers(std::map<std::string, std::string>({
-        {"Content-Type", "text/plain"},
+        {"Content-Type", "application/json"},
       }));
       json::value json_response = json::object({
         {"status_code", json::number(404)},

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -64,7 +64,7 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
         {"Content-Type", "text/plain"},
       }));
       json::value json_response = json::object({
-        {"status_code", json::int(404)},
+        {"status_code", json::number(404)},
         {"error", json::string("Not found")},
       });
       conn->write(json_response->ToString());

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -47,12 +47,10 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
       if (config_.VerboseLogging()) {
         LOG(INFO) << "Found resource for " << id << ": " << resource;
       }
-      std::map<std::string, std::string> headers = {
-        {"Content-Type", "application/json"},
-      };
-
       conn->set_status(HttpServer::connection::ok);
-      conn->set_headers(headers);
+      conn->set_headers(std::map<std::string, std::string>({
+        {"Content-Type", "application/json"},
+      }));
       conn->write(resource.ToJSON()->ToString());
     } catch (const std::out_of_range& e) {
       // TODO: This could be considered log spam.
@@ -61,11 +59,10 @@ void MetadataApiServer::Handler::operator()(const HttpServer::request& request,
       if (config_.VerboseLogging()) {
         LOG(WARNING) << "No matching resource for " << id;
       }
-      std::map<std::string, std::string> headers = {
-        {"Content-Type", "text/plain"},
-      };
       conn->set_status(HttpServer::connection::not_found);
-      conn->set_headers(headers);
+      conn->set_headers(std::map<std::string, std::string>({
+        {"Content-Type", "text/plain"},
+      }));
     }
   }
 }


### PR DESCRIPTION
This was introduced in #78.