### PR TITLE
Separate ValidateConfiguration into the static and dynamic parts.

### DIFF
--- a/src/docker.cc
+++ b/src/docker.cc
@@ -58,7 +58,7 @@ class DockerReader::NonRetriableError : public DockerReader::QueryException {
 DockerReader::DockerReader(const Configuration& config)
     : config_(config), environment_(config) {}
 
-void DockerReader::ValidateConfiguration() const
+void DockerReader::ValidateDynamicConfiguration() const
     throw(MetadataUpdater::ConfigurationValidationError) {
   const std::string container_filter(
       config_.DockerContainerFilter().empty()
@@ -230,10 +230,10 @@ json::value DockerReader::QueryDocker(const std::string& path) const
   }
 }
 
-void DockerUpdater::ValidateConfiguration() const
+void DockerUpdater::ValidateDynamicConfiguration() const
     throw(ConfigurationValidationError) {
-  PollingMetadataUpdater::ValidateConfiguration();
-  reader_.ValidateConfiguration();
+  PollingMetadataUpdater::ValidateDynamicConfiguration();
+  reader_.ValidateDynamicConfiguration();
 }
 
 }

--- a/src/docker.h
+++ b/src/docker.h
@@ -35,8 +35,8 @@ class DockerReader {
   // A Docker metadata query function.
   std::vector<MetadataUpdater::ResourceMetadata> MetadataQuery() const;
 
-  // Validates the relevant configuration and throws if it's incorrect.
-  void ValidateConfiguration() const
+  // Validates the relevant dynamic configuration and throws if it's incorrect.
+  void ValidateDynamicConfiguration() const
       throw(MetadataUpdater::ConfigurationValidationError);
 
  private:
@@ -73,7 +73,7 @@ class DockerUpdater : public PollingMetadataUpdater {
           [=]() { return reader_.MetadataQuery(); }) { }
 
  protected:
-  void ValidateConfiguration() const throw(ConfigurationValidationError);
+  void ValidateDynamicConfiguration() const throw(ConfigurationValidationError);
 
  private:
   DockerReader reader_;

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -1072,7 +1072,7 @@ void KubernetesReader::UpdateServiceToPodsCache(
   }
 }
 
-void KubernetesReader::ValidateConfiguration() const
+void KubernetesReader::ValidateDynamicConfiguration() const
     throw(MetadataUpdater::ConfigurationValidationError) {
   try {
     util::Retry<NonRetriableError, QueryException>(
@@ -1268,10 +1268,10 @@ KubernetesUpdater::KubernetesUpdater(const Configuration& config,
         config.KubernetesUpdaterIntervalSeconds(),
         [=]() { return reader_.MetadataQuery(); }) { }
 
-void KubernetesUpdater::ValidateConfiguration() const
+void KubernetesUpdater::ValidateDynamicConfiguration() const
     throw(ConfigurationValidationError) {
-  PollingMetadataUpdater::ValidateConfiguration();
-  reader_.ValidateConfiguration();
+  PollingMetadataUpdater::ValidateDynamicConfiguration();
+  reader_.ValidateDynamicConfiguration();
 }
 
 bool KubernetesUpdater::ShouldStartUpdater() const {

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -43,8 +43,8 @@ class KubernetesReader {
   // A Kubernetes metadata query function.
   std::vector<MetadataUpdater::ResourceMetadata> MetadataQuery() const;
 
-  // Validates the relevant configuration and throws if it's incorrect.
-  void ValidateConfiguration() const
+  // Validates the relevant dynamic configuration and throws if it's incorrect.
+  void ValidateDynamicConfiguration() const
       throw(MetadataUpdater::ConfigurationValidationError);
 
   // Node watcher.
@@ -227,7 +227,7 @@ class KubernetesUpdater : public PollingMetadataUpdater {
   }
 
  protected:
-  void ValidateConfiguration() const throw(ConfigurationValidationError);
+  void ValidateDynamicConfiguration() const throw(ConfigurationValidationError);
   bool ShouldStartUpdater() const;
 
   void StartUpdater();

--- a/src/updater.cc
+++ b/src/updater.cc
@@ -31,9 +31,10 @@ MetadataUpdater::MetadataUpdater(const Configuration& config,
 MetadataUpdater::~MetadataUpdater() {}
 
 void MetadataUpdater::start() throw(ConfigurationValidationError) {
-  ValidateConfiguration();
+  ValidateStaticConfiguration();
 
   if (ShouldStartUpdater()) {
+    ValidateDynamicConfiguration();
     StartUpdater();
   } else {
     LOG(INFO) << "Not starting " << name_;
@@ -60,7 +61,7 @@ PollingMetadataUpdater::~PollingMetadataUpdater() {
   }
 }
 
-void PollingMetadataUpdater::ValidateConfiguration() const
+void PollingMetadataUpdater::ValidateStaticConfiguration() const
     throw(ConfigurationValidationError) {
   if (period_ < time::seconds::zero()) {
     throw ConfigurationValidationError(

--- a/src/updater.h
+++ b/src/updater.h
@@ -81,10 +81,10 @@ class MetadataUpdater {
  protected:
   friend class UpdaterTest;
 
-  // Validates the relevant configuration.
+  // Validates static properties of the relevant configuration.
   // If the configuration is invalid, throws a ConfigurationValidationError,
   // which is generally expected to pass through and terminate the program.
-  virtual void ValidateConfiguration() const
+  virtual void ValidateStaticConfiguration() const
       throw(ConfigurationValidationError) {}
 
   // Decides whether the updater logic should be started based on the current
@@ -92,6 +92,13 @@ class MetadataUpdater {
   virtual bool ShouldStartUpdater() const {
     return true;
   }
+
+  // Validates dynamic properties of the relevant configuration.
+  // If the configuration is invalid, throws a ConfigurationValidationError,
+  // which is generally expected to pass through and terminate the program.
+  // This should only run when we know the updater is about to be started.
+  virtual void ValidateDynamicConfiguration() const
+      throw(ConfigurationValidationError) {}
 
   // Internal method for starting the updater's logic.
   virtual void StartUpdater() = 0;
@@ -135,7 +142,8 @@ class PollingMetadataUpdater : public MetadataUpdater {
  protected:
   friend class UpdaterTest;
 
-  void ValidateConfiguration() const throw(ConfigurationValidationError);
+  void ValidateStaticConfiguration() const throw(ConfigurationValidationError);
+  using MetadataUpdater::ValidateDynamicConfiguration;
   bool ShouldStartUpdater() const;
   void StartUpdater();
   void StopUpdater();


### PR DESCRIPTION
This is a follow-on to #134.