### PR TITLE
Shut down gracefully on SIGTERM.

### DIFF
--- a/src/agent.cc
+++ b/src/agent.cc
@@ -28,7 +28,7 @@ MetadataAgent::MetadataAgent(const Configuration& config)
 
 MetadataAgent::~MetadataAgent() {}
 
-void MetadataAgent::start() {
+void MetadataAgent::Start() {
   metadata_api_server_.reset(new MetadataApiServer(
       config_, store_, config_.MetadataApiNumThreads(), "0.0.0.0",
       config_.MetadataApiPort()));
@@ -36,7 +36,7 @@ void MetadataAgent::start() {
       config_, &store_, config_.MetadataReporterIntervalSeconds()));
 }
 
-void MetadataAgent::stop() {
+void MetadataAgent::Stop() {
   metadata_api_server_.reset();
   reporter_.reset();
 }

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -36,4 +36,9 @@ void MetadataAgent::start() {
       config_, &store_, config_.MetadataReporterIntervalSeconds()));
 }
 
+void MetadataAgent::stop() {
+  metadata_api_server_.reset();
+  reporter_.reset();
+}
+
 }

--- a/src/agent.cc
+++ b/src/agent.cc
@@ -37,8 +37,8 @@ void MetadataAgent::Start() {
 }
 
 void MetadataAgent::Stop() {
-  metadata_api_server_.reset();
-  reporter_.reset();
+  metadata_api_server_->Stop();
+  // TODO: Notify the metadata reporter as well.
 }
 
 }

--- a/src/agent.h
+++ b/src/agent.h
@@ -39,10 +39,10 @@ class MetadataAgent {
   ~MetadataAgent();
 
   // Starts serving.
-  void start();
+  void Start();
 
   // Stops serving.
-  void stop();
+  void Stop();
 
   const Configuration& config() const {
     return config_;

--- a/src/agent.h
+++ b/src/agent.h
@@ -41,6 +41,9 @@ class MetadataAgent {
   // Starts serving.
   void start();
 
+  // Stops serving.
+  void stop();
+
   const Configuration& config() const {
     return config_;
   }

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -90,6 +90,7 @@ MetadataApiServer::MetadataApiServer(const Configuration& config,
 
 MetadataApiServer::~MetadataApiServer() {
   server_.stop();
+  LOG(INFO) << "API server stopped";
   for (auto& thread : server_pool_) {
     thread.join();
   }

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -88,9 +88,13 @@ MetadataApiServer::MetadataApiServer(const Configuration& config,
   }
 }
 
-MetadataApiServer::~MetadataApiServer() {
+void MetadataApiServer::Stop() {
   server_.stop();
   LOG(INFO) << "API server stopped";
+}
+
+MetadataApiServer::~MetadataApiServer() {
+  Stop();
   for (auto& thread : server_pool_) {
     thread.join();
   }

--- a/src/api_server.cc
+++ b/src/api_server.cc
@@ -84,11 +84,12 @@ MetadataApiServer::MetadataApiServer(const Configuration& config,
       server_pool_()
 {
   for (int i : boost::irange(0, server_threads)) {
-    server_pool_.emplace_back(&HttpServer::run, &server_);
+    server_pool_.emplace_back([=]() { server_.run(); });
   }
 }
 
 MetadataApiServer::~MetadataApiServer() {
+  server_.stop();
   for (auto& thread : server_pool_) {
     thread.join();
   }

--- a/src/api_server.h
+++ b/src/api_server.h
@@ -43,6 +43,9 @@ class MetadataApiServer {
                     int server_threads, const std::string& host, int port);
   ~MetadataApiServer();
 
+  // Stops the server and closes the listening socket.
+  void Stop();
+
  private:
   friend class ApiServerTest;
 

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -1321,29 +1321,12 @@ void KubernetesUpdater::StartUpdater() {
   }
 }
 
-void KubernetesUpdater::StopUpdater() {
-  // TODO: How do we interrupt a watch thread?
+void KubernetesUpdater::NotifyStopUpdater() {
   if (config().KubernetesUseWatch()) {
-#if 0
-    if (node_watch_thread_.joinable()) {
-      node_watch_thread_.join();
-    }
-    if (pod_watch_thread_.joinable()) {
-      pod_watch_thread_.join();
-    }
-    if (config().KubernetesClusterLevelMetadata() &&
-        config().KubernetesServiceMetadata()) {
-      if (service_watch_thread_.joinable()) {
-        service_watch_thread_.join();
-      }
-      if (endpoints_watch_thread_.joinable()) {
-        endpoints_watch_thread_.join();
-      }
-    }
-#endif
+    // TODO: How do we interrupt a watch thread?
   } else {
     // Only stop polling if watch is disabled.
-    PollingMetadataUpdater::StopUpdater();
+    PollingMetadataUpdater::NotifyStopUpdater();
   }
 }
 

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -1321,6 +1321,22 @@ void KubernetesUpdater::StartUpdater() {
   }
 }
 
+void KubernetesUpdater::StopUpdater() {
+  // TODO: How do we interrupt a watch thread?
+  if (config().KubernetesUseWatch()) {
+    node_watch_thread_.join();
+    pod_watch_thread_.join();
+    if (config().KubernetesClusterLevelMetadata() &&
+        config().KubernetesServiceMetadata()) {
+      service_watch_thread_.join();
+      endpoints_watch_thread_.join();
+    }
+  } else {
+    // Only stop polling if watch is disabled.
+    PollingMetadataUpdater::StopUpdater();
+  }
+}
+
 void KubernetesUpdater::MetadataCallback(
     std::vector<MetadataUpdater::ResourceMetadata>&& result_vector) {
   for (MetadataUpdater::ResourceMetadata& result : result_vector) {

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -1324,13 +1324,23 @@ void KubernetesUpdater::StartUpdater() {
 void KubernetesUpdater::StopUpdater() {
   // TODO: How do we interrupt a watch thread?
   if (config().KubernetesUseWatch()) {
-    node_watch_thread_.join();
-    pod_watch_thread_.join();
+#if 0
+    if (node_watch_thread_.joinable()) {
+      node_watch_thread_.join();
+    }
+    if (pod_watch_thread_.joinable()) {
+      pod_watch_thread_.join();
+    }
     if (config().KubernetesClusterLevelMetadata() &&
         config().KubernetesServiceMetadata()) {
-      service_watch_thread_.join();
-      endpoints_watch_thread_.join();
+      if (service_watch_thread_.joinable()) {
+        service_watch_thread_.join();
+      }
+      if (endpoints_watch_thread_.joinable()) {
+        endpoints_watch_thread_.join();
+      }
     }
+#endif
   } else {
     // Only stop polling if watch is disabled.
     PollingMetadataUpdater::StopUpdater();

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -231,7 +231,7 @@ class KubernetesUpdater : public PollingMetadataUpdater {
   bool ShouldStartUpdater() const;
 
   void StartUpdater();
-  void StopUpdater();
+  void NotifyStopUpdater();
 
  private:
   // Metadata watcher callback.

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -231,6 +231,7 @@ class KubernetesUpdater : public PollingMetadataUpdater {
   bool ShouldStartUpdater() const;
 
   void StartUpdater();
+  void StopUpdater();
 
  private:
   // Metadata watcher callback.

--- a/src/metadatad.cc
+++ b/src/metadatad.cc
@@ -17,6 +17,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <initializer_list>
+#include <iostream>
 
 #include "agent.h"
 #include "configuration.h"
@@ -40,10 +41,14 @@ const CleanupState* cleanup_state;
 }  // google
 
 extern "C" [[noreturn]] void handle_sigterm(int signum) {
-  google::cleanup_state->server->stop();
+  std::cerr << "Caught SIGTERM; shutting down" << std::endl;
+  std::cerr << "Stopping updaters" << std::endl;
   for (google::MetadataUpdater* updater : google::cleanup_state->updaters) {
     updater->stop();
   }
+  std::cerr << "Stopping server" << std::endl;
+  google::cleanup_state->server->stop();
+  std::cerr << "Exiting" << std::endl;
   std::exit(128 + signum);
 }
 

--- a/src/metadatad.cc
+++ b/src/metadatad.cc
@@ -65,7 +65,7 @@ extern "C" [[noreturn]] void handle_sigterm(int signum) {
   std::cerr << "Caught SIGTERM; shutting down" << std::endl;
   google::cleanup_state->StartShutdown();
   std::cerr << "Exiting" << std::endl;
-  std::exit(128 + signum);
+  std::exit(0);  // SIGTERM means graceful shutdown, so report success.
 }
 
 int main(int ac, char** av) {

--- a/src/metadatad.cc
+++ b/src/metadatad.cc
@@ -24,6 +24,7 @@
 #include "docker.h"
 #include "instance.h"
 #include "kubernetes.h"
+#include "time.h"
 
 namespace google {
 namespace {
@@ -42,6 +43,8 @@ class CleanupState {
       updater->NotifyStop();
     }
     server_wait_mutex_.unlock();
+    // Give the notifications some time to propagate.
+    std::this_thread::sleep_for(time::seconds(0.1));
   }
 
   void Wait() const {

--- a/src/updater.cc
+++ b/src/updater.cc
@@ -77,7 +77,7 @@ bool PollingMetadataUpdater::ShouldStartUpdater() const {
 void PollingMetadataUpdater::StartUpdater() {
   timer_.lock();
   if (config().VerboseLogging()) {
-    LOG(INFO) << "Timer locked";
+    LOG(INFO) << "Locked timer for " << name();
   }
   reporter_thread_ = std::thread([=]() { PollForMetadata(); });
 }
@@ -85,7 +85,7 @@ void PollingMetadataUpdater::StartUpdater() {
 void PollingMetadataUpdater::StopUpdater() {
   timer_.unlock();
   if (config().VerboseLogging()) {
-    LOG(INFO) << "Timer unlocked";
+    LOG(INFO) << "Unlocked timer for " << name();
   }
 }
 
@@ -99,7 +99,7 @@ void PollingMetadataUpdater::PollForMetadata() {
     }
     // An unlocked timer means we should stop updating.
     if (config().VerboseLogging()) {
-      LOG(INFO) << "Trying to unlock the timer";
+      LOG(INFO) << "Trying to unlock the timer for " << name();
     }
     auto start = std::chrono::high_resolution_clock::now();
     auto wakeup = start + period_;
@@ -113,7 +113,7 @@ void PollingMetadataUpdater::PollForMetadata() {
       if (config().VerboseLogging()) {
         LOG(INFO) << " Timer unlock timed out after "
                   << std::chrono::duration_cast<time::seconds>(now - start).count()
-                  << "s (good)";
+                  << "s (good) for " << name();
       }
       start = now;
       wakeup = start + period_;
@@ -121,7 +121,7 @@ void PollingMetadataUpdater::PollForMetadata() {
     }
   } while (!done);
   if (config().VerboseLogging()) {
-    LOG(INFO) << "Timer unlocked (stop polling)";
+    LOG(INFO) << "Timer unlocked (stop polling) for " << name();
   }
 }
 

--- a/src/updater.cc
+++ b/src/updater.cc
@@ -30,7 +30,7 @@ MetadataUpdater::MetadataUpdater(const Configuration& config,
 
 MetadataUpdater::~MetadataUpdater() {}
 
-void MetadataUpdater::start() throw(ConfigurationValidationError) {
+void MetadataUpdater::Start() throw(ConfigurationValidationError) {
   ValidateStaticConfiguration();
 
   if (ShouldStartUpdater()) {
@@ -41,8 +41,8 @@ void MetadataUpdater::start() throw(ConfigurationValidationError) {
   }
 }
 
-void MetadataUpdater::stop() {
-  StopUpdater();
+void MetadataUpdater::NotifyStop() {
+  NotifyStopUpdater();
 }
 
 PollingMetadataUpdater::PollingMetadataUpdater(
@@ -82,7 +82,7 @@ void PollingMetadataUpdater::StartUpdater() {
   reporter_thread_ = std::thread([=]() { PollForMetadata(); });
 }
 
-void PollingMetadataUpdater::StopUpdater() {
+void PollingMetadataUpdater::NotifyStopUpdater() {
   timer_.unlock();
   if (config().VerboseLogging()) {
     LOG(INFO) << "Unlocked timer for " << name();

--- a/src/updater.h
+++ b/src/updater.h
@@ -104,6 +104,7 @@ class MetadataUpdater {
   virtual void StartUpdater() = 0;
 
   // Internal method for stopping the updater's logic.
+  // This method should not perform any blocking operations (e.g., wait).
   virtual void StopUpdater() = 0;
 
   // Updates the resource map in the store.

--- a/src/updater.h
+++ b/src/updater.h
@@ -116,6 +116,10 @@ class MetadataUpdater {
     store_->UpdateMetadata(result.resource_, std::move(result.metadata_));
   }
 
+  const std::string& name() const {
+    return name_;
+  }
+
   const Configuration& config() const {
     return config_;
   }

--- a/src/updater.h
+++ b/src/updater.h
@@ -70,10 +70,10 @@ class MetadataUpdater {
   virtual ~MetadataUpdater();
 
   // Starts updating.
-  void start() throw(ConfigurationValidationError);
+  void Start() throw(ConfigurationValidationError);
 
-  // Stops updating.
-  void stop();
+  // Notifies the updater to stop updating.
+  void NotifyStop();
 
   using UpdateCallback =
       std::function<void(std::vector<MetadataUpdater::ResourceMetadata>&&)>;
@@ -103,9 +103,9 @@ class MetadataUpdater {
   // Internal method for starting the updater's logic.
   virtual void StartUpdater() = 0;
 
-  // Internal method for stopping the updater's logic.
+  // Internal method for notifying the updater's to stop its logic.
   // This method should not perform any blocking operations (e.g., wait).
-  virtual void StopUpdater() = 0;
+  virtual void NotifyStopUpdater() = 0;
 
   // Updates the resource map in the store.
   void UpdateResourceCallback(const ResourceMetadata& result) {
@@ -151,7 +151,7 @@ class PollingMetadataUpdater : public MetadataUpdater {
   using MetadataUpdater::ValidateDynamicConfiguration;
   bool ShouldStartUpdater() const;
   void StartUpdater();
-  void StopUpdater();
+  void NotifyStopUpdater();
 
  private:
   friend class InstanceTest;

--- a/test/updater_unittest.cc
+++ b/test/updater_unittest.cc
@@ -109,7 +109,7 @@ class MockMetadataUpdater : public MetadataUpdater {
   void StartUpdater() {
     call_sequence_.push_back("StartUpdater");
   }
-  void StopUpdater() {}
+  void NotifyStopUpdater() {}
 
   mutable std::vector<std::string> call_sequence_;
 
@@ -125,7 +125,7 @@ TEST_F(ValidationOrderingTest, FailedStaticCheckStopsOtherChecks) {
       /*fail_static=*/true,
       /*should_start=*/true,
       /*fail_dynamic=*/true);
-  EXPECT_THROW(updater.start(), MetadataUpdater::ConfigurationValidationError);
+  EXPECT_THROW(updater.Start(), MetadataUpdater::ConfigurationValidationError);
   EXPECT_EQ(
       std::vector<std::string>({
           "ValidateStaticConfiguration",
@@ -139,7 +139,7 @@ TEST_F(ValidationOrderingTest, FalseShouldStartUpdaterStopsDynamicChecks) {
       /*fail_static=*/false,
       /*should_start=*/false,
       /*fail_dynamic=*/false);
-  EXPECT_NO_THROW(updater.start());
+  EXPECT_NO_THROW(updater.Start());
   EXPECT_EQ(
       std::vector<std::string>({
           "ValidateStaticConfiguration",
@@ -154,7 +154,7 @@ TEST_F(ValidationOrderingTest, FailedDynamicCheckStopsStartUpdater) {
       /*fail_static=*/false,
       /*should_start=*/true,
       /*fail_dynamic=*/true);
-  EXPECT_THROW(updater.start(), MetadataUpdater::ConfigurationValidationError);
+  EXPECT_THROW(updater.Start(), MetadataUpdater::ConfigurationValidationError);
   EXPECT_EQ(
       std::vector<std::string>({
           "ValidateStaticConfiguration",
@@ -170,7 +170,7 @@ TEST_F(ValidationOrderingTest, AllChecksPassedInvokesStartUpdater) {
       /*fail_static=*/false,
       /*should_start=*/true,
       /*fail_dynamic=*/false);
-  EXPECT_NO_THROW(updater.start());
+  EXPECT_NO_THROW(updater.Start());
   EXPECT_EQ(
       std::vector<std::string>({
           "ValidateStaticConfiguration",


### PR DESCRIPTION
This doesn't fully work, because the agent gets stuck waiting on joining threads, but a second SIGTERM usually does the trick. It does shut down the server first, though.