### PR TITLE
Ignore uninitialized JSON values when constructing arrays and objects.

### DIFF
--- a/src/json.cc
+++ b/src/json.cc
@@ -162,14 +162,18 @@ Array::Array(const Array& other) {
 
 Array::Array(std::vector<std::unique_ptr<Value>>&& elements) {
   for (auto& e : elements) {
-    emplace_back(std::move(e));
+    if (e != nullptr) {
+      emplace_back(std::move(e));
+    }
   }
 }
 
 Array::Array(
     std::initializer_list<rref_capture<std::unique_ptr<Value>>> elements) {
   for (auto& e : elements) {
-    emplace_back(std::move(e));
+    if (((std::unique_ptr<Value>&&) e) != nullptr) {
+      emplace_back(std::move(e));
+    }
   }
 }
 
@@ -193,7 +197,9 @@ Object::Object(const Object& other) {
 
 Object::Object(std::map<std::string, std::unique_ptr<Value>>&& fields) {
   for (auto& kv : fields) {
-    emplace(kv.first, std::move(kv.second));
+    if (kv.second != nullptr) {
+      emplace(kv.first, std::move(kv.second));
+    }
   }
 }
 
@@ -201,7 +207,9 @@ Object::Object(
     std::initializer_list<std::pair<std::string,
                           rref_capture<std::unique_ptr<Value>>>> fields) {
   for (auto& kv : fields) {
-    emplace(kv.first, std::move(kv.second));
+    if (((std::unique_ptr<Value>&&) kv.second) != nullptr) {
+      emplace(kv.first, std::move(kv.second));
+    }
   }
 }
 

--- a/src/json.h
+++ b/src/json.h
@@ -219,7 +219,11 @@ template<typename T> class rref_capture {
 class Array : public Value, public std::vector<std::unique_ptr<Value>> {
  public:
   Array() {}
+  // Construct an array with the specified elements.
+  // nullptr elements will be discarded.
   Array(std::vector<std::unique_ptr<Value>>&& elements);
+  // Construct an array with the specified elements.
+  // nullptr elements will be discarded.
   Array(std::initializer_list<rref_capture<std::unique_ptr<Value>>> elements);
   Array(const Array& other);
 
@@ -234,7 +238,11 @@ class Array : public Value, public std::vector<std::unique_ptr<Value>> {
 class Object : public Value, public std::map<std::string, std::unique_ptr<Value>> {
  public:
   Object() {}
+  // Construct an object with the specified fields.
+  // nullptr values will be discarded.
   Object(std::map<std::string, std::unique_ptr<Value>>&& fields);
+  // Construct an object with the specified fields.
+  // nullptr values will be discarded.
   Object(std::initializer_list<std::pair<std::string, rref_capture<std::unique_ptr<Value>>>> fields);
   Object(const Object& other);
 

--- a/src/json.h
+++ b/src/json.h
@@ -239,10 +239,10 @@ class Object : public Value, public std::map<std::string, std::unique_ptr<Value>
  public:
   Object() {}
   // Construct an object with the specified fields.
-  // nullptr values will be discarded.
+  // Key/value pairs with nullptr values will be discarded.
   Object(std::map<std::string, std::unique_ptr<Value>>&& fields);
   // Construct an object with the specified fields.
-  // nullptr values will be discarded.
+  // Key/value pairs with nullptr values will be discarded.
   Object(std::initializer_list<std::pair<std::string, rref_capture<std::unique_ptr<Value>>>> fields);
   Object(const Object& other);
 

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -205,15 +205,12 @@ json::value KubernetesReader::ComputePodAssociations(const json::Object* pod)
     node_name = json::string(spec->Get<json::String>("nodeName"));
   }
 
+  // If controllers or node_name are not populated, they will be discarded.
   json::value raw_associations = json::object({
     {"infrastructureResource", std::move(instance_resource)},
     {"controllers", std::move(controllers)},
-    {"nodeName", json::string(spec->Get<json::String>("nodeName"))},
+    {"nodeName", std::move(node_name)},
   });
-
-  if (raw_associations->As<json::Object>()->empty()) {
-    return json::value();
-  }
 
   return json::object({
     {"version", json::string(config_.MetadataIngestionRawContentVersion())},

--- a/test/json_unittest.cc
+++ b/test/json_unittest.cc
@@ -733,10 +733,15 @@ TEST(EdgeTest, NegativeNumbers) {
 TEST(BigTest, RealisticConstruction) {
   GuardJsonException([](){
     json::value v = json::object({
-      {"foo", json::array({json::number(1), json::number(2), json::number(3)})},
+      {"foo", json::array({
+        // Uninitialized values are ignored.
+        json::number(1), json::value(), json::number(2), json::number(3)
+      })},
+      {"uninitialized1", json::value()},  // Uninitialized values are ignored.
       {"bar", json::object({{"x", json::number(0)}, {"y", json::null()}})},
       {"baz", json::boolean(true)},
       {"str", json::string("asdfasdf")},
+      {"uninitialized2", json::value()},  // Uninitialized values are ignored.
     });
     EXPECT_TOSTRING_EQ(
       "{"


### PR DESCRIPTION
* Make use of this fact when constructing metadata.