### PR TITLE
Remove container metadata, and all associations.

### DIFF
--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -122,17 +122,8 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetNodeMetadata(
     {"location", location},
   });
 
-  json::value instance_resource =
-      InstanceReader::InstanceResource(environment_).ToJSON();
-
   json::value node_raw_metadata = json::object({
     {"blobs", json::object({
-      {"association", json::object({
-        {"version", json::string(config_.MetadataIngestionRawContentVersion())},
-        {"raw", json::object({
-          {"infrastructureResource", std::move(instance_resource)},
-        })},
-      })},
       {"api", json::object({
         {"version", json::string(kKubernetesApiVersion)},
         {"raw", node->Clone()},
@@ -159,69 +150,9 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetNodeMetadata(
   );
 }
 
-json::value KubernetesReader::ComputePodAssociations(const json::Object* pod)
-    const throw(json::Exception) {
-  const json::Object* metadata = pod->Get<json::Object>("metadata");
-  const std::string namespace_name = metadata->Get<json::String>("namespace");
-
-  json::value instance_resource =
-      InstanceReader::InstanceResource(environment_).ToJSON();
-
-  std::unique_ptr<json::Object> raw_associations(new json::Object({
-    {"infrastructureResource", std::move(instance_resource)},
-  }));
-
-  try {
-    const json::value top_level = FindTopLevelController(
-        namespace_name, pod->Clone());
-    const json::Object* top_level_controller = top_level->As<json::Object>();
-    const json::Object* top_level_metadata =
-        top_level_controller->Get<json::Object>("metadata");
-    const std::string top_level_name =
-        top_level_metadata->Get<json::String>("name");
-    const std::string pod_id = metadata->Get<json::String>("uid");
-    if (!top_level_controller->Has("kind") &&
-        top_level_metadata->Get<json::String>("uid") != pod_id) {
-      LOG(ERROR) << "Internal error; top-level controller without 'kind' "
-                 << *top_level_controller
-                 << " not the same as pod " << *pod;
-    }
-    const std::string top_level_kind =
-        top_level_controller->Has("kind")
-            ? top_level_controller->Get<json::String>("kind")
-            : "Pod";
-
-    raw_associations->emplace(std::make_pair(
-      "controllers",
-      json::object({
-        {"topLevelControllerType", json::string(top_level_kind)},
-        {"topLevelControllerName", json::string(top_level_name)},
-      })
-    ));
-  } catch (const QueryException& e) {
-    LOG(ERROR) << "Error while finding top-level controller for "
-               << namespace_name << "." << metadata->Get<json::String>("name")
-               << ": " << e.what();
-  }
-
-  const json::Object* spec = pod->Get<json::Object>("spec");
-  if (spec->Has("nodeName")) {
-    // Pods that have been scheduled will have a nodeName.
-    raw_associations->emplace(std::make_pair(
-      "nodeName",
-      json::string(spec->Get<json::String>("nodeName"))
-    ));
-  }
-
-  return json::object({
-    {"version", json::string(config_.MetadataIngestionRawContentVersion())},
-    {"raw", json::value(std::move(raw_associations))},
-  });
-}
-
 MetadataUpdater::ResourceMetadata KubernetesReader::GetPodMetadata(
-    const json::Object* pod, json::value associations, Timestamp collected_at,
-    bool is_deleted) const throw(json::Exception) {
+    const json::Object* pod, Timestamp collected_at, bool is_deleted) const
+    throw(json::Exception) {
   const std::string cluster_name = environment_.KubernetesClusterName();
   const std::string location = environment_.KubernetesClusterLocation();
 
@@ -242,7 +173,6 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetPodMetadata(
 
   json::value pod_raw_metadata = json::object({
     {"blobs", json::object({
-      {"association", std::move(associations)},
       {"api", json::object({
         {"version", json::string(kKubernetesApiVersion)},
         {"raw", pod->Clone()},
@@ -274,8 +204,7 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetPodMetadata(
 
 MetadataUpdater::ResourceMetadata KubernetesReader::GetContainerMetadata(
     const json::Object* pod, const json::Object* container_spec,
-    const json::Object* container_status, json::value associations,
-    Timestamp collected_at, bool is_deleted) const throw(json::Exception) {
+    const json::Object* container_status, Timestamp collected_at, bool is_deleted) const throw(json::Exception) {
   const std::string cluster_name = environment_.KubernetesClusterName();
   const std::string location = environment_.KubernetesClusterLocation();
 
@@ -286,12 +215,6 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetContainerMetadata(
   const std::string created_str =
       metadata->Get<json::String>("creationTimestamp");
   Timestamp created_at = time::rfc3339::FromString(created_str);
-  const json::Object* labels;
-  if (!metadata->Has("labels")) {
-    labels = nullptr;
-  } else {
-    labels = metadata->Get<json::Object>("labels");
-  }
 
   const std::string container_name = container_spec->Get<json::String>("name");
 
@@ -302,38 +225,6 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetContainerMetadata(
     {"container_name", container_name},
     {"location", location},
   });
-
-  std::unique_ptr<json::Object> blobs(new json::Object({
-    {"association", std::move(associations)},
-    {"spec", json::object({
-      {"version", json::string(kKubernetesApiVersion)},
-      {"raw", container_spec->Clone()},
-    })},
-  }));
-  if (container_status) {
-    blobs->emplace(std::make_pair(
-      "status",
-      json::object({
-        {"version", json::string(kKubernetesApiVersion)},
-        {"raw", container_status->Clone()},
-      })
-    ));
-  }
-  if (labels) {
-    blobs->emplace(std::make_pair(
-      "labels",
-      json::object({
-        {"version", json::string(kKubernetesApiVersion)},
-        {"raw", labels->Clone()},
-      })
-    ));
-  }
-  json::value container_raw_metadata = json::object({
-    {"blobs", json::value(std::move(blobs))},
-  });
-  if (config_.VerboseLogging()) {
-    LOG(INFO) << "Raw container metadata: " << *container_raw_metadata;
-  }
 
   const std::string k8s_container_pod = boost::algorithm::join(
       std::vector<std::string>{kK8sContainerResourcePrefix, pod_id, container_name},
@@ -370,13 +261,7 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetContainerMetadata(
   return MetadataUpdater::ResourceMetadata(
       std::move(local_resource_ids),
       k8s_container,
-#ifdef ENABLE_KUBERNETES_METADATA
-      MetadataStore::Metadata(kKubernetesApiVersion,
-                              is_deleted, created_at, collected_at,
-                              std::move(container_raw_metadata))
-#else
       MetadataStore::Metadata::IGNORED()
-#endif
   );
 }
 
@@ -418,8 +303,6 @@ KubernetesReader::GetPodAndContainerMetadata(
     const json::Object* pod, Timestamp collected_at, bool is_deleted) const
     throw(json::Exception) {
   std::vector<MetadataUpdater::ResourceMetadata> result;
-
-  json::value associations = ComputePodAssociations(pod);
 
   const json::Object* metadata = pod->Get<json::Object>("metadata");
   const std::string pod_name = metadata->Get<json::String>("name");
@@ -466,11 +349,10 @@ KubernetesReader::GetPodAndContainerMetadata(
     result.emplace_back(GetLegacyResource(pod, name));
     result.emplace_back(
         GetContainerMetadata(pod, container_spec, container_status,
-                             associations->Clone(), collected_at, is_deleted));
+                             collected_at, is_deleted));
   }
 
-  result.emplace_back(
-      GetPodMetadata(pod, std::move(associations), collected_at, is_deleted));
+  result.emplace_back(GetPodMetadata(pod, collected_at, is_deleted));
   return std::move(result);
 }
 
@@ -870,144 +752,6 @@ const std::string& KubernetesReader::CurrentNode() const {
     }
   }
   return current_node_;
-}
-
-std::pair<std::string, std::string> KubernetesReader::KindPath(
-    const std::string& version, const std::string& kind) const {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  const std::string prefix(
-      (version.find('/') == std::string::npos) ? "/api" : "/apis");
-  const std::string query_path(prefix + "/" + version);
-  auto found = version_to_kind_to_name_.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(version),
-      std::forward_as_tuple());
-  std::map<std::string, std::string>& kind_to_name = found.first->second;
-  if (found.second) {  // Not found, inserted new.
-    try {
-      json::value apilist_response = QueryMaster(query_path);
-      if (config_.VerboseLogging()) {
-        LOG(INFO) << "Parsed API list: " << *apilist_response;
-      }
-
-      const json::Object* apilist_object = apilist_response->As<json::Object>();
-      const json::Array* api_list = apilist_object->Get<json::Array>("resources");
-      for (const json::value& element : *api_list) {
-        const json::Object* resource = element->As<json::Object>();
-        const std::string resource_name = resource->Get<json::String>("name");
-        // Hack: the API seems to return multiple names for the same kind.
-        if (resource_name.find('/') != std::string::npos) {
-          continue;
-        }
-        const std::string resource_kind = resource->Get<json::String>("kind");
-        kind_to_name.emplace(resource_kind, resource_name);
-      }
-    } catch (const json::Exception& e) {
-      LOG(ERROR) << e.what();
-    } catch (const QueryException& e) {
-      // Already logged.
-    }
-  }
-
-  auto name_it = kind_to_name.find(kind);
-  if (name_it == kind_to_name.end()) {
-    throw std::string("Unknown kind: ") + kind;
-  }
-  return {query_path, name_it->second};
-}
-
-json::value KubernetesReader::GetOwner(
-    const std::string& ns, const json::Object* owner_ref) const
-    throw(QueryException, json::Exception) {
-#ifdef VERBOSE
-  LOG(DEBUG) << "GetOwner(" << ns << ", " << *owner_ref << ")";
-#endif
-  const std::string api_version = owner_ref->Get<json::String>("apiVersion");
-  const std::string kind = owner_ref->Get<json::String>("kind");
-  const std::string name = owner_ref->Get<json::String>("name");
-  const std::string uid = owner_ref->Get<json::String>("uid");
-
-  // Even though we query by name, we should look up the owner by uid,
-  // to handle the case when an object is deleted and re-constructed.
-  const std::string encoded_ref = boost::algorithm::join(
-      std::vector<std::string>{api_version, kind, uid}, "/");
-
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  auto found = owners_.emplace(std::piecewise_construct,
-                               std::forward_as_tuple(encoded_ref),
-                               std::forward_as_tuple());
-  json::value& owner = found.first->second;
-  if (found.second) {  // Not found, inserted new.
-    const auto path_component = KindPath(api_version, kind);
-#ifdef VERBOSE
-    LOG(DEBUG) << "KindPath returned {" << path_component.first << ", "
-               << path_component.second << "}";
-#endif
-    owner = std::move(
-        QueryMaster(path_component.first + "/namespaces/" + ns + "/" +
-                    path_component.second + "/" + name));
-    // Sanity check: because we are looking up by name, the object we get
-    // back might have a different uid.
-    const json::Object* owner_obj = owner->As<json::Object>();
-    const json::Object* metadata = owner_obj->Get<json::Object>("metadata");
-    const std::string owner_uid = metadata->Get<json::String>("uid");
-    if (owner_uid != uid) {
-      LOG(WARNING) << "Owner " << kind << "'" << name << "' (id " << uid
-                   << ") disappeared before we could query it. Found id "
-                   << owner_uid << " instead.";
-      owner.reset();
-      throw QueryException("Owner " + kind + " " + name + " (id " + uid +
-                           ") disappeared");
-    }
-  }
-  return owner->Clone();
-}
-
-json::value KubernetesReader::FindTopLevelController(
-    const std::string& ns, json::value object) const
-    throw(QueryException, json::Exception) {
-  const json::Object* obj = object->As<json::Object>();
-#ifdef VERBOSE
-  LOG(DEBUG) << "Looking for the top-level owner for " << *obj;
-#endif
-  const json::Object* metadata = obj->Get<json::Object>("metadata");
-#ifdef VERBOSE
-  LOG(DEBUG) << "FindTopLevelController: metadata is " << *metadata;
-#endif
-  if (!metadata->Has("ownerReferences")) {
-#ifdef VERBOSE
-    LOG(DEBUG) << "FindTopLevelController: no owner references in "
-               << *metadata;
-#endif
-    return object;
-  }
-  const json::Array* refs = metadata->Get<json::Array>("ownerReferences");
-#ifdef VERBOSE
-  LOG(DEBUG) << "FindTopLevelController: refs is " << *refs;
-#endif
-
-  // Kubernetes objects are supposed to have at most one controller:
-  // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#objectmeta-v1-meta.
-  const json::Object* controller_ref = nullptr;
-  for (const json::value& ref : *refs) {
-    const json::Object* ref_obj = ref->As<json::Object>();
-    if (ref_obj->Has("controller") &&
-        ref_obj->Get<json::Boolean>("controller")) {
-      controller_ref = ref_obj;
-      break;
-    }
-  }
-  if (!controller_ref) {
-#ifdef VERBOSE
-    LOG(DEBUG) << "FindTopLevelController: no controller references in "
-               << *refs;
-#endif
-    return object;
-  }
-#ifdef VERBOSE
-  LOG(DEBUG) << "FindTopLevelController: controller_ref is " << *controller_ref;
-#endif
-  return FindTopLevelController(ns, GetOwner(ns, controller_ref));
 }
 
 void KubernetesReader::UpdateServiceToMetadataCache(

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -112,22 +112,19 @@ class KubernetesReader {
       MetadataUpdater::UpdateCallback callback, const json::Object* endpoints,
       Timestamp collected_at, bool is_deleted) throw(json::Exception);
 
-  // Compute the associations for a given pod.
-  json::value ComputePodAssociations(const json::Object* pod) const
-      throw(json::Exception);
   // Given a node object, return the associated metadata.
   MetadataUpdater::ResourceMetadata GetNodeMetadata(
       const json::Object* node, Timestamp collected_at, bool is_deleted) const
       throw(json::Exception);
   // Given a pod object, return the associated metadata.
   MetadataUpdater::ResourceMetadata GetPodMetadata(
-      const json::Object* pod, json::value associations, Timestamp collected_at,
-      bool is_deleted) const throw(json::Exception);
+      const json::Object* pod, Timestamp collected_at, bool is_deleted) const
+      throw(json::Exception);
   // Given a pod object and container info, return the container metadata.
   MetadataUpdater::ResourceMetadata GetContainerMetadata(
       const json::Object* pod, const json::Object* container_spec,
-      const json::Object* container_status, json::value associations,
-      Timestamp collected_at, bool is_deleted) const throw(json::Exception);
+      const json::Object* container_status, Timestamp collected_at,
+      bool is_deleted) const throw(json::Exception);
   // Given a pod object and container name, return the legacy resource.
   // The returned "metadata" field will be Metadata::IGNORED.
   MetadataUpdater::ResourceMetadata GetLegacyResource(
@@ -154,18 +151,6 @@ class KubernetesReader {
   // Returns an empty string if unable to find the namespace.
   const std::string& KubernetesNamespace() const;
 
-  // Given a version string, returns the path and name for a given kind.
-  std::pair<std::string, std::string> KindPath(const std::string& version,
-                                               const std::string& kind) const;
-
-  // Follows the owner reference to get the corresponding object.
-  json::value GetOwner(const std::string& ns, const json::Object* owner_ref)
-      const throw(QueryException, json::Exception);
-
-  // For a given object, returns the top-level controller object.
-  json::value FindTopLevelController(const std::string& ns, json::value object)
-      const throw(QueryException, json::Exception);
-
   // Update service_to_metadata_ cache based on a newly updated service.
   void UpdateServiceToMetadataCache(
       const json::Object* service, bool is_deleted) throw(json::Exception);
@@ -187,8 +172,6 @@ class KubernetesReader {
   // A memoized map from version to a map from kind to name.
   mutable std::map<std::string, std::map<std::string, std::string>>
       version_to_kind_to_name_;
-  // A memoized map from an encoded owner reference to the owner object.
-  mutable std::map<std::string, json::value> owners_;
 
   // ServiceKey is a pair of the namespace name and the service name that
   // uniquely identifies a service in a cluster.

--- a/test/kubernetes_unittest.cc
+++ b/test/kubernetes_unittest.cc
@@ -17,20 +17,16 @@ class KubernetesTest : public ::testing::Test {
 
   static MetadataUpdater::ResourceMetadata GetPodMetadata(
       const KubernetesReader& reader, const json::Object* pod,
-      json::value associations, Timestamp collected_at, bool is_deleted)
-      throw(json::Exception) {
-    return reader.GetPodMetadata(
-        pod, std::move(associations), collected_at, is_deleted);
+      Timestamp collected_at, bool is_deleted) throw(json::Exception) {
+    return reader.GetPodMetadata(pod, collected_at, is_deleted);
   }
 
   static MetadataUpdater::ResourceMetadata GetContainerMetadata(
       const KubernetesReader& reader, const json::Object* pod,
       const json::Object* container_spec, const json::Object* container_status,
-      json::value associations, Timestamp collected_at, bool is_deleted)
-      throw(json::Exception) {
+      Timestamp collected_at, bool is_deleted) throw(json::Exception) {
     return reader.GetContainerMetadata(pod, container_spec, container_status,
-                                       std::move(associations), collected_at,
-                                       is_deleted);
+                                       collected_at, is_deleted);
   }
 
   static std::vector<MetadataUpdater::ResourceMetadata> GetPodAndContainerMetadata(
@@ -43,16 +39,6 @@ class KubernetesTest : public ::testing::Test {
       const KubernetesReader& reader, const json::Object* pod,
       const std::string& container_name) throw(json::Exception) {
     return reader.GetLegacyResource(pod, container_name);
-  }
-
-  static json::value ComputePodAssociations(const KubernetesReader& reader,
-                                     const json::Object* pod) {
-    return reader.ComputePodAssociations(pod);
-  }
-
-  static void UpdateOwnersCache(KubernetesReader* reader, const std::string& key,
-                         const json::value& value) {
-    reader->owners_[key] = value->Clone();
   }
 
   static MetadataUpdater::ResourceMetadata GetClusterMetadata(
@@ -105,86 +91,15 @@ TEST_F(KubernetesTest, GetNodeMetadata) {
   EXPECT_EQ(time::rfc3339::FromString("2018-03-03T01:23:45.678901234Z"),
             m.metadata().created_at);
   EXPECT_EQ(Timestamp(), m.metadata().collected_at);
-  json::value big = json::object({
+  json::value expected_metadata = json::object({
     {"blobs", json::object({
-      {"association", json::object({
-        {"version", json::string("TestVersion")},
-        {"raw", json::object({
-          {"infrastructureResource", json::object({
-            {"type", json::string("gce_instance")},
-            {"labels", json::object({
-              {"instance_id", json::string("TestID")},
-              {"zone", json::string("TestZone")},
-            })},
-          })},
-        })},
-      })},
       {"api", json::object({
         {"version", json::string("1.6")},  // Hard-coded in kubernetes.cc.
         {"raw", std::move(node)},
       })},
     })},
   });
-  EXPECT_EQ(big->ToString(), m.metadata().metadata->ToString());
-}
-
-TEST_F(KubernetesTest, ComputePodAssociations) {
-  Configuration config(std::stringstream(
-    "KubernetesClusterName: TestClusterName\n"
-    "KubernetesClusterLocation: TestClusterLocation\n"
-    "MetadataIngestionRawContentVersion: TestVersion\n"
-    "InstanceZone: TestZone\n"
-    "InstanceId: TestID\n"
-  ));
-  Environment environment(config);
-  KubernetesReader reader(config, nullptr);  // Don't need HealthChecker.
-  json::value controller = json::object({
-    {"controller", json::boolean(true)},
-    {"apiVersion", json::string("1.2.3")},
-    {"kind", json::string("TestKind")},
-    {"name", json::string("TestName")},
-    {"uid", json::string("TestUID1")},
-    {"metadata", json::object({
-      {"name", json::string("InnerTestName")},
-      {"kind", json::string("InnerTestKind")},
-      {"uid", json::string("InnerTestUID1")},
-    })},
-  });
-  UpdateOwnersCache(&reader, "1.2.3/TestKind/TestUID1", controller);
-  json::value pod = json::object({
-    {"metadata", json::object({
-      {"namespace", json::string("TestNamespace")},
-      {"uid", json::string("TestUID0")},
-      {"ownerReferences", json::array({
-        json::object({{"no_controller", json::boolean(true)}}),
-        std::move(controller),
-      })},
-    })},
-    {"spec", json::object({
-      {"nodeName", json::string("TestSpecNodeName")},
-    })},
-  });
-
-  json::value expected_associations = json::object({
-    {"raw", json::object({
-      {"controllers", json::object({
-        {"topLevelControllerName", json::string("InnerTestName")},
-        {"topLevelControllerType", json::string("TestKind")},
-      })},
-      {"infrastructureResource", json::object({
-        {"labels", json::object({
-          {"instance_id", json::string("TestID")},
-          {"zone", json::string("TestZone")},
-        })},
-        {"type", json::string("gce_instance")},
-      })},
-      {"nodeName", json::string("TestSpecNodeName")},
-    })},
-    {"version", json::string("TestVersion")},
-  });
-  const auto associations =
-      ComputePodAssociations(reader, pod->As<json::Object>());
-  EXPECT_EQ(expected_associations->ToString(), associations->ToString());
+  EXPECT_EQ(expected_metadata->ToString(), m.metadata().metadata->ToString());
 }
 
 TEST_F(KubernetesTest, GetPodMetadata) {
@@ -206,8 +121,7 @@ TEST_F(KubernetesTest, GetPodMetadata) {
     })},
   });
   const auto m = GetPodMetadata(reader, pod->As<json::Object>(),
-                                json::string("TestAssociations"), Timestamp(),
-                                false);
+                                Timestamp(), false);
 
   EXPECT_EQ(std::vector<std::string>(
       {"k8s_pod.TestUid", "k8s_pod.TestNamespace.TestName"}), m.ids());
@@ -237,7 +151,6 @@ TEST_F(KubernetesTest, GetPodMetadata) {
         })},
         {"version", json::string("1.6")},
       })},
-      {"association", json::string("TestAssociations")},
     })},
   });
   EXPECT_EQ(expected_metadata->ToString(), m.metadata().metadata->ToString());
@@ -468,7 +381,6 @@ TEST_F(KubernetesTest, GetContainerMetadata) {
       pod->As<json::Object>(),
       spec->As<json::Object>(),
       status->As<json::Object>(),
-      json::string("TestAssociations"),
       Timestamp(),
       /*is_deleted=*/false);
 
@@ -484,37 +396,9 @@ TEST_F(KubernetesTest, GetContainerMetadata) {
     {"namespace_name", "TestNamespace"},
     {"pod_name", "TestName"},
   }), m.resource());
-  EXPECT_EQ("1.6", m.metadata().version);
-  EXPECT_FALSE(m.metadata().is_deleted);
-  EXPECT_EQ(time::rfc3339::FromString("2018-03-03T01:23:45.678901234Z"),
-            m.metadata().created_at);
-  EXPECT_EQ(Timestamp(), m.metadata().collected_at);
-  EXPECT_FALSE(m.metadata().ignore);
-  json::value expected_metadata = json::object({
-    {"blobs", json::object({
-      {"association", json::string("TestAssociations")},
-      {"labels", json::object({
-        {"raw", json::object({
-          {"label", json::string("TestLabel")},
-        })},
-        {"version", json::string("1.6")},
-      })},
-      {"spec", json::object({
-        {"raw", json::object({
-          {"name", json::string("TestSpecName")},
-        })},
-        {"version", json::string("1.6")},
-      })},
-      {"status", json::object({
-        {"raw", json::object({
-          {"containerID", json::string("docker://TestContainerID")},
-        })},
-        {"version", json::string("1.6")},
-      })},
-    })},
-  });
-  EXPECT_EQ(expected_metadata->ToString(), m.metadata().metadata->ToString());
+  EXPECT_TRUE(m.metadata().ignore);
 }
+
 TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
   Configuration config(std::stringstream(
     "KubernetesClusterName: TestClusterName\n"
@@ -527,19 +411,6 @@ TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
   Environment environment(config);
   KubernetesReader reader(config, nullptr);  // Don't need HealthChecker.
 
-  json::value controller = json::object({
-    {"controller", json::boolean(true)},
-    {"apiVersion", json::string("1.2.3")},
-    {"kind", json::string("TestKind")},
-    {"name", json::string("TestName")},
-    {"uid", json::string("TestUID1")},
-    {"metadata", json::object({
-      {"name", json::string("InnerTestName")},
-      {"kind", json::string("InnerTestKind")},
-      {"uid", json::string("InnerTestUID1")},
-    })},
-  });
-  UpdateOwnersCache(&reader, "1.2.3/TestKind/TestUID1", controller);
   json::value pod = json::object({
     {"metadata", json::object({
       {"name", json::string("TestPodName")},
@@ -591,46 +462,7 @@ TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
     {"namespace_name", "TestNamespace"},
     {"pod_name", "TestPodName"},
   }), m[1].resource());
-  EXPECT_FALSE(m[1].metadata().ignore);
-  EXPECT_EQ("1.6", m[1].metadata().version);
-  EXPECT_FALSE(m[1].metadata().is_deleted);
-  EXPECT_EQ(time::rfc3339::FromString("2018-03-03T01:23:45.678901234Z"),
-            m[1].metadata().created_at);
-  EXPECT_EQ(Timestamp(), m[1].metadata().collected_at);
-  json::value container_metadata = json::object({
-    {"blobs", json::object({
-      {"association", json::object({
-        {"raw", json::object({
-          {"controllers", json::object({
-            {"topLevelControllerName", json::string("TestPodName")},
-            {"topLevelControllerType", json::string("Pod")},
-          })},
-          {"infrastructureResource", json::object({
-            {"labels", json::object({
-              {"instance_id", json::string("TestID")},
-              {"zone", json::string("TestZone")},
-            })},
-            {"type", json::string("gce_instance")},
-          })},
-          {"nodeName", json::string("TestSpecNodeName")},
-        })},
-        {"version", json::string("TestVersion")},
-      })},
-      {"spec", json::object({
-        {"raw", json::object({
-          {"name", json::string("TestContainerName0")},
-        })},
-        {"version", json::string("1.6")},
-      })},
-      {"status", json::object({
-        {"raw", json::object({
-          {"name", json::string("TestContainerName0")},
-        })},
-        {"version", json::string("1.6")},
-      })},
-    })},
-  });
-  EXPECT_EQ(container_metadata->ToString(), m[1].metadata().metadata->ToString());
+  EXPECT_TRUE(m[1].metadata().ignore);
 
   EXPECT_EQ(std::vector<std::string>({
     "k8s_pod.TestPodUid",
@@ -673,23 +505,6 @@ TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
           })},
         })},
         {"version", json::string("1.6")},
-      })},
-      {"association", json::object({
-        {"raw", json::object({
-          {"controllers", json::object({
-            {"topLevelControllerName", json::string("TestPodName")},
-            {"topLevelControllerType", json::string("Pod")},
-          })},
-          {"infrastructureResource", json::object({
-            {"labels", json::object({
-              {"instance_id", json::string("TestID")},
-              {"zone", json::string("TestZone")},
-            })},
-            {"type", json::string("gce_instance")},
-          })},
-          {"nodeName", json::string("TestSpecNodeName")},
-        })},
-        {"version", json::string("TestVersion")},
       })},
     })},
   });


### PR DESCRIPTION
Since v1beta3 API will construct the container metadata, the agent does
not need to send it over. Further, all associations will be created API
side too - so dropping them as well.