### PR TITLE
Node pod metadata

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -47,8 +47,7 @@ constexpr const int kMetadataReporterDefaultPurgeDeleted = false;
 constexpr const char kMetadataReporterDefaultUserAgent[] =
     "metadata-agent/" STRINGIFY(AGENT_VERSION);
 constexpr const char kMetadataIngestionDefaultEndpointFormat[] =
-    "https://stackdriver.googleapis.com/v1beta3/projects/{{project_id}}"
-    "/resourceMetadata:publish";
+    "https://stackdriver.googleapis.com/batch/resourceMetadata";
 constexpr const int kMetadataIngestionDefaultRequestSizeLimitBytes =
     8*1024*1024;
 constexpr const int kMetadataIngestionDefaultRequestSizeLimitCount = 1000;

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -142,9 +142,10 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetNodeMetadata(
   const std::string k8s_node_name = boost::algorithm::join(
       std::vector<std::string>{kK8sNodeResourcePrefix, node_name},
       config_.MetadataApiResourceTypeSeparator());
-  const std::string node_full_name = format::Substitute(
-      kNodeFullNameFormat,
-      {{"cluster_full_name", ClusterFullName()}, {"node_name", node_name}});
+  const std::string node_full_name =
+      format::Substitute(kNodeFullNameFormat,
+                         {{"cluster_full_name", ClusterFullName()},
+                          {"node_name", node_name}});
   return MetadataUpdater::ResourceMetadata(
       std::vector<std::string>{k8s_node_name},
       k8s_node,
@@ -191,10 +192,11 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetPodMetadata(
   const std::string k8s_pod_name = boost::algorithm::join(
       std::vector<std::string>{kK8sPodResourcePrefix, namespace_name, pod_name},
       config_.MetadataApiResourceTypeSeparator());
-  const std::string pod_full_name = format::Substitute(
-      kPodFullNameFormat,
-      {{"cluster_full_name", ClusterFullName()},
-        {"namespace_name", namespace_name}, {"pod_name", pod_name}});
+  const std::string pod_full_name =
+      format::Substitute(kPodFullNameFormat,
+                         {{"cluster_full_name", ClusterFullName()},
+                          {"namespace_name", namespace_name},
+                          {"pod_name", pod_name}});
   return MetadataUpdater::ResourceMetadata(
       std::vector<std::string>{k8s_pod_id, k8s_pod_name},
       k8s_pod,
@@ -520,12 +522,11 @@ const std::string KubernetesReader::ClusterFullName() const {
   const std::string location = environment_.KubernetesClusterLocation();
   int num_dashes = std::count(location.begin(), location.end(), '-');
   const std::string location_type = num_dashes == 2 ? "zones": "locations";
-  return format::Substitute(
-      kClusterFullNameFormat,
-      {{"project_id", project_id},
-       {"location_type", location_type},
-       {"location", location},
-       {"cluster_name", cluster_name}});
+  return format::Substitute(kClusterFullNameFormat,
+                            {{"project_id", project_id},
+                             {"location_type", location_type},
+                             {"location", location},
+                             {"cluster_name", cluster_name}});
 }
 
 namespace {

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -520,6 +520,10 @@ const std::string KubernetesReader::ClusterFullName() const {
   const std::string project_id = environment_.NumericProjectId();
   const std::string cluster_name = environment_.KubernetesClusterName();
   const std::string location = environment_.KubernetesClusterLocation();
+
+  // The two lines below are GCP specific, and are used to distinguish between
+  // zones (e.g. "us-central1-a", "us-east1-b") and regions (e.g.
+  // "us-central1", "us-east1").
   int num_dashes = std::count(location.begin(), location.end(), '-');
   const std::string location_type = num_dashes == 2 ? "zones": "locations";
   return format::Substitute(kClusterFullNameFormat,

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -66,6 +66,13 @@ constexpr const char kDockerIdPrefix[] = "docker://";
 
 constexpr const char kServiceAccountDirectory[] =
     "/var/run/secrets/kubernetes.io/serviceaccount";
+constexpr const char kKubernetesSchemaNameFormat[] =
+    "//container.googleapis.com/resourceTypes/{{type}}/versions/{{version}}";
+
+constexpr const char kKubernetesClusterFullNameFormat[] =
+    "//container.googleapis.com/projects/{{project_id}}/{{location_type}}/"
+    "{{location}}/clusters/{{cluster_name}}";
+
 
 // Returns the full path to the secret filename.
 std::string SecretPath(const std::string& secret) {
@@ -108,40 +115,38 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetNodeMetadata(
     const json::Object* node, Timestamp collected_at, bool is_deleted) const
     throw(json::Exception) {
   const std::string cluster_name = environment_.KubernetesClusterName();
-  const std::string location = environment_.KubernetesClusterLocation();
+  const std::string cluster_location = environment_.KubernetesClusterLocation();
 
   const json::Object* metadata = node->Get<json::Object>("metadata");
   const std::string node_name = metadata->Get<json::String>("name");
+  const std::string node_version = node->Get<json::String>("apiVersion");
+  const std::string node_type = "io.k8s.Node";
+  const std::string node_schema =
+      format::Substitute(std::string(kKubernetesSchemaNameFormat),
+                         {{"type", node_type}, {"version", node_version}});
 
   const MonitoredResource k8s_node("k8s_node", {
     {"cluster_name", cluster_name},
     {"node_name", node_name},
-    {"location", location},
+    {"location", cluster_location},
   });
 
-  json::value node_raw_metadata = json::object({
-    {"blobs", json::object({
-      {"api", json::object({
-        {"version", json::string(kKubernetesApiVersion)},
-        {"raw", node->Clone()},
-      })},
-    })},
-  });
   if (config_.VerboseLogging()) {
-    LOG(INFO) << "Raw node metadata: " << *node_raw_metadata;
+    LOG(INFO) << "Raw node metadata: " << *node;
   }
 
   const std::string k8s_node_name = boost::algorithm::join(
       std::vector<std::string>{kK8sNodeResourcePrefix, node_name},
       config_.MetadataApiResourceTypeSeparator());
+  const std::string node_full_name =
+      ClusterFullName() + "/k8s/nodes/" + node_name;
   return MetadataUpdater::ResourceMetadata(
       std::vector<std::string>{k8s_node_name},
       k8s_node,
 #ifdef ENABLE_KUBERNETES_METADATA
-      MetadataStore::Metadata(/*name=*/"", /*type=*/"", /*location=*/"",
-                              /*version=*/"", /*schema_name=*/"",
-                              is_deleted, collected_at,
-                              std::move(node_raw_metadata))
+      MetadataStore::Metadata(node_full_name, node_type, cluster_location,
+                              node_version, node_schema,
+                              is_deleted, collected_at, node->Clone())
 #else
       MetadataStore::Metadata::IGNORED()
 #endif
@@ -152,30 +157,27 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetPodMetadata(
     const json::Object* pod, Timestamp collected_at, bool is_deleted) const
     throw(json::Exception) {
   const std::string cluster_name = environment_.KubernetesClusterName();
-  const std::string location = environment_.KubernetesClusterLocation();
+  const std::string cluster_location = environment_.KubernetesClusterLocation();
 
   const json::Object* metadata = pod->Get<json::Object>("metadata");
   const std::string namespace_name = metadata->Get<json::String>("namespace");
   const std::string pod_name = metadata->Get<json::String>("name");
   const std::string pod_id = metadata->Get<json::String>("uid");
+  const std::string pod_version = pod->Get<json::String>("apiVersion");
+  const std::string pod_type = "io.k8s.Pod";
+  const std::string pod_schema =
+      format::Substitute(std::string(kKubernetesSchemaNameFormat),
+                         {{"type", pod_type}, {"version", pod_version}});
 
   const MonitoredResource k8s_pod("k8s_pod", {
     {"cluster_name", cluster_name},
     {"namespace_name", namespace_name},
     {"pod_name", pod_name},
-    {"location", location},
+    {"location", cluster_location},
   });
 
-  json::value pod_raw_metadata = json::object({
-    {"blobs", json::object({
-      {"api", json::object({
-        {"version", json::string(kKubernetesApiVersion)},
-        {"raw", pod->Clone()},
-      })},
-    })},
-  });
   if (config_.VerboseLogging()) {
-    LOG(INFO) << "Raw pod metadata: " << *pod_raw_metadata;
+    LOG(INFO) << "Raw pod metadata: " << *pod;
   }
 
   const std::string k8s_pod_id = boost::algorithm::join(
@@ -184,14 +186,16 @@ MetadataUpdater::ResourceMetadata KubernetesReader::GetPodMetadata(
   const std::string k8s_pod_name = boost::algorithm::join(
       std::vector<std::string>{kK8sPodResourcePrefix, namespace_name, pod_name},
       config_.MetadataApiResourceTypeSeparator());
+  const std::string pod_full_name =
+      ClusterFullName() + "/k8s/namespaces/" + namespace_name + "/pods/" +
+      pod_name;
   return MetadataUpdater::ResourceMetadata(
       std::vector<std::string>{k8s_pod_id, k8s_pod_name},
       k8s_pod,
 #ifdef ENABLE_KUBERNETES_METADATA
-      MetadataStore::Metadata(/*name=*/"", /*type=*/"", /*location=*/"",
-                              /*version=*/"", /*schema_name=*/"",
-                              is_deleted, collected_at,
-                              std::move(pod_raw_metadata))
+      MetadataStore::Metadata(pod_full_name, pod_type, cluster_location,
+                              pod_version, pod_schema,
+                              is_deleted, collected_at, pod->Clone())
 #else
       MetadataStore::Metadata::IGNORED()
 #endif
@@ -502,6 +506,20 @@ json::value KubernetesReader::QueryMaster(const std::string& path) const
     LOG(ERROR) << "Failed to query " << endpoint << ": " << e.what();
     throw QueryException(endpoint + " -> " + e.what());
   }
+}
+
+const std::string KubernetesReader::ClusterFullName() const {
+  const std::string project_id = environment_.NumericProjectId();
+  const std::string cluster_name = environment_.KubernetesClusterName();
+  const std::string location = environment_.KubernetesClusterLocation();
+  int num_dashes = std::count(location.begin(), location.end(), '-');
+  const std::string location_type = num_dashes == 2 ? "zones": "locations";
+  return format::Substitute(
+      std::string(kKubernetesClusterFullNameFormat),
+      {{"project_id", project_id},
+       {"location_type", location_type},
+       {"location", location},
+       {"cluster_name", cluster_name}});
 }
 
 namespace {

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -76,6 +76,10 @@ class KubernetesReader {
   json::value QueryMaster(const std::string& path) const
       throw(QueryException, json::Exception);
 
+  // Builds the cluster full name by reading in cluster related environment
+  // variables.
+  const std::string ClusterFullName() const;
+
   // Issues a Kubernetes master API query at a given path and
   // watches for parsed JSON responses. The path has to start with "/".
   // Invokes callback for every notification.

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -96,7 +96,7 @@ class KubernetesReader {
       MetadataUpdater::UpdateCallback callback, const json::Object* pod,
       Timestamp collected_at, bool is_deleted) const throw(json::Exception);
 
-  // Builds the cluster full name by reading in cluster related environment
+  // Builds the cluster full name by reading from cluster related environment
   // variables.
   const std::string ClusterFullName() const;
 

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -76,10 +76,6 @@ class KubernetesReader {
   json::value QueryMaster(const std::string& path) const
       throw(QueryException, json::Exception);
 
-  // Builds the cluster full name by reading in cluster related environment
-  // variables.
-  const std::string ClusterFullName() const;
-
   // Issues a Kubernetes master API query at a given path and
   // watches for parsed JSON responses. The path has to start with "/".
   // Invokes callback for every notification.
@@ -99,6 +95,10 @@ class KubernetesReader {
   void PodCallback(
       MetadataUpdater::UpdateCallback callback, const json::Object* pod,
       Timestamp collected_at, bool is_deleted) const throw(json::Exception);
+
+  // Builds the cluster full name by reading in cluster related environment
+  // variables.
+  const std::string ClusterFullName() const;
 
   // Given a node object, return the associated metadata.
   MetadataUpdater::ResourceMetadata GetNodeMetadata(

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -96,8 +96,7 @@ class KubernetesReader {
       MetadataUpdater::UpdateCallback callback, const json::Object* pod,
       Timestamp collected_at, bool is_deleted) const throw(json::Exception);
 
-  // Builds the cluster full name by reading from cluster related environment
-  // variables.
+  // Builds the cluster full name from cluster related environment variables.
   const std::string ClusterFullName() const;
 
   // Given a node object, return the associated metadata.

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -29,6 +29,11 @@ namespace http = boost::network::http;
 
 namespace google {
 
+constexpr const char kMultipartBoundary[] = "publishMultipartPost";
+constexpr const char kBatchPath[] = "/batch/resourceMetadata";
+constexpr const char kPublishPathFormat[] =
+    "/v1beta3/projects/{{project_id}}/resourceMetadata:publish";
+
 MetadataReporter::MetadataReporter(const Configuration& config,
                                    MetadataStore* store, double period_s)
     : store_(store),
@@ -71,40 +76,94 @@ void MetadataReporter::ReportMetadata() {
 namespace {
 
 void SendMetadataRequest(std::vector<json::value>&& entries,
-                         const std::string& endpoint,
+                         const std::string& batch_uri,
+                         const std::string& publish_path,
                          const std::string& auth_header,
                          const std::string& user_agent,
                          bool verbose_logging)
     throw (boost::system::system_error) {
-  json::value update_metadata_request = json::object({
-    {"entries", json::array(std::move(entries))},
-  });
+
+  if (entries.size() == 1) {
+    // Add a copy of the single entry, except for the `views` field. This allows
+    // us to sent a request to the batch endpoint when we have a single request.
+    const json::Object* single_request = entries[0]->As<json::Object>();
+    json::value duplicate_request = json::object({  // ResourceMetadata
+      {"name", json::string(single_request->Get<json::String>("name"))},
+      {"type", json::string(single_request->Get<json::String>("type"))},
+      {"location", json::string(single_request->Get<json::String>("location"))},
+      {"state", json::string(single_request->Get<json::String>("state"))},
+      {"eventTime",
+        json::string(single_request->Get<json::String>("eventTime"))},
+    });
+    entries.emplace_back(std::move(duplicate_request));
+  }
+  const std::string content_type =
+      std::string("multipart/mixed; boundary=") + kMultipartBoundary;
+  http::client client;
+  http::client::request request(batch_uri);
+  request << boost::network::header("User-Agent", user_agent);
+  request << boost::network::header("Content-Type", content_type);
+  request << boost::network::header("Authorization", auth_header);
+  request << boost::network::header("Expect", "100-continue");
+  std::ostringstream out;
+  out << std::endl;
+
+  for (json::value& entry : entries) {
+    const json::Object* single_request = entry->As<json::Object>();
+    std::string request_body = single_request->ToString();
+    out << "--" << kMultipartBoundary << std::endl;
+    out << "Content-Type: application/http" << std::endl;
+    out << "Content-Transfer-Encoding: binary" << std::endl;
+    out << "Content-ID: " << single_request->Get<json::String>("name")
+        << std::endl;
+    out << std::endl;
+    out << "POST " << publish_path << std::endl;
+    out << "Content-Type: application/json; charset=UTF-8" << std::endl;
+    out << "Content-Length: " << std::to_string(request_body.size())
+        << std::endl;
+    out << std::endl << request_body << std::endl;
+  }
+  out << "--" << kMultipartBoundary << "--" << std::endl;
+  std::string multipart_body = out.str();
+  const int total_length = multipart_body.size();
+
+  request << boost::network::header("Content-Length",
+                                    std::to_string(total_length));
+  request << boost::network::body(multipart_body);
 
   if (verbose_logging) {
-    LOG(INFO) << "About to send request: POST " << endpoint
-              << " User-Agent: " << user_agent
-              << " " << *update_metadata_request;
+    LOG(INFO) << "About to send request: POST " << batch_uri;
+    LOG(INFO) << "Headers:";
+    http::client::request::headers_container_type head = (headers(request));
+    for (auto it = head.begin(); it != head.end(); ++it) {
+      if (it->first == "Authorization") {
+        continue;
+      }
+      LOG(INFO) << it->first << ": " << it->second;
+    }
+    LOG(INFO) << "Body:" << std::endl << body(request);
   }
 
-  http::client client;
-  http::client::request request(endpoint);
-  std::string request_body = update_metadata_request->ToString();
-  request << boost::network::header("User-Agent", user_agent);
-  request << boost::network::header("Content-Length",
-                                    std::to_string(request_body.size()));
-  request << boost::network::header("Content-Type", "application/json");
-  request << boost::network::header("Authorization", auth_header);
-  request << boost::network::body(request_body);
   http::client::response response = client.post(request);
   if (status(response) >= 300) {
     throw boost::system::system_error(
-        boost::system::errc::make_error_code(boost::system::errc::not_connected),
+        boost::system::errc::make_error_code(
+            boost::system::errc::not_connected),
         format::Substitute("Server responded with '{{message}}' ({{code}})",
                            {{"message", status_message(response)},
                             {"code", format::str(status(response))}}));
   }
   if (verbose_logging) {
-    LOG(INFO) << "Server responded with " << body(response);
+    LOG(INFO) << format::Substitute(
+        "Server responded with '{{message}}' ({{code}})",
+        {{"message", status_message(response)},
+         {"code", format::str(status(response))}});
+    LOG(INFO) << "Headers:";
+    http::client::response::headers_container_type head = (headers(response));
+    for (auto it = head.begin(); it != head.end(); ++it) {
+      LOG(INFO) << it->first << ": " << it->second;
+    }
+    LOG(INFO) << "Body:" << std::endl << body(response);
   }
   // TODO: process response.
 }
@@ -125,11 +184,9 @@ void MetadataReporter::SendMetadata(
     LOG(INFO) << "Sending request to the server";
   }
   const std::string project_id = environment_.NumericProjectId();
-  // The endpoint template is expected to be of the form
-  // "https://stackdriver.googleapis.com/.../projects/{{project_id}}/...".
-  const std::string endpoint =
-      format::Substitute(config_.MetadataIngestionEndpointFormat(),
-                         {{"project_id", project_id}});
+  const std::string& batch_uri = config_.MetadataIngestionEndpointFormat();
+  const std::string& publish_path =
+      format::Substitute(kPublishPathFormat, {{"project_id", project_id}});
   const std::string auth_header = auth_.GetAuthHeaderValue();
   const std::string user_agent = config_.MetadataReporterUserAgent();
 
@@ -172,8 +229,8 @@ void MetadataReporter::SendMetadata(
       continue;
     }
     if (entries.size() == limit_count || total_size + size > limit_bytes) {
-      SendMetadataRequest(std::move(entries), endpoint, auth_header, user_agent,
-                          config_.VerboseLogging());
+      SendMetadataRequest(std::move(entries), batch_uri, publish_path,
+                          auth_header, user_agent, config_.VerboseLogging());
       entries.clear();
       total_size = empty_size;
     }
@@ -181,8 +238,8 @@ void MetadataReporter::SendMetadata(
     total_size += size;
   }
   if (!entries.empty()) {
-    SendMetadataRequest(std::move(entries), endpoint, auth_header, user_agent,
-                        config_.VerboseLogging());
+    SendMetadataRequest(std::move(entries), batch_uri, publish_path,
+                        auth_header, user_agent, config_.VerboseLogging());
   }
 }
 

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -170,6 +170,9 @@ void SendMetadataRequest(std::vector<json::value>&& entries,
 
 std::string MetadataReporter::FullyQualifiedResourceLocation(
     const std::string& location) const {
+  // The code below is GCP specific. It first distinguishes between zones (e.g.
+  // "us-central1-a", "us-east1-b") and regions (e.g. "us-central1", "us-east1")
+  // and builds the full resource location.
   int num_dashes = std::count(location.begin(), location.end(), '-');
   const std::string location_type = num_dashes == 2 ? "zones" : "regions";
   return format::Substitute(

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -142,7 +142,7 @@ void SendMetadataRequest(std::vector<json::value>&& entries,
 
   if (verbose_logging) {
     LOG(INFO) << "About to send request: POST " << endpoint;
-    LOG(INFO) << "Headers:" << request.headers();
+    LOG(INFO) << "Headers: " << request.headers();
     LOG(INFO) << "Body:" << std::endl << body(request);
   }
 
@@ -168,7 +168,7 @@ void SendMetadataRequest(std::vector<json::value>&& entries,
 
 }
 
-const std::string MetadataReporter::FullyQualifiedResourceLocation(
+std::string MetadataReporter::FullyQualifiedResourceLocation(
     const std::string& location) const {
   int num_dashes = std::count(location.begin(), location.end(), '-');
   const std::string location_type = num_dashes == 2 ? "zones" : "regions";

--- a/src/reporter.h
+++ b/src/reporter.h
@@ -48,6 +48,11 @@ class MetadataReporter {
   void SendMetadata(std::vector<MetadataStore::Metadata>&& metadata)
       throw (boost::system::system_error);
 
+  // Create the fully qualified location based on the raw location reported by
+  // the metadata server.
+  const std::string FullyQualifiedResourceLocation(const std::string location)
+      const;
+
   const Configuration& config_;
   MetadataStore* store_;
   Environment environment_;

--- a/src/reporter.h
+++ b/src/reporter.h
@@ -50,8 +50,7 @@ class MetadataReporter {
 
   // Create the fully qualified location based on the raw location reported by
   // the metadata server.
-  const std::string FullyQualifiedResourceLocation(const std::string& location)
-      const;
+  std::string FullyQualifiedResourceLocation(const std::string& location) const;
 
   const Configuration& config_;
   MetadataStore* store_;

--- a/src/reporter.h
+++ b/src/reporter.h
@@ -50,7 +50,7 @@ class MetadataReporter {
 
   // Create the fully qualified location based on the raw location reported by
   // the metadata server.
-  const std::string FullyQualifiedResourceLocation(const std::string location)
+  const std::string FullyQualifiedResourceLocation(const std::string& location)
       const;
 
   const Configuration& config_;

--- a/test/configuration_unittest.cc
+++ b/test/configuration_unittest.cc
@@ -14,8 +14,7 @@ void VerifyDefaultConfig(const Configuration& config) {
   EXPECT_EQ(false, config.MetadataReporterPurgeDeleted());
   EXPECT_THAT(config.MetadataReporterUserAgent(),
               ::testing::StartsWith("metadata-agent/"));
-  EXPECT_EQ("https://stackdriver.googleapis.com/"
-            "v1beta3/projects/{{project_id}}/resourceMetadata:publish",
+  EXPECT_EQ("https://stackdriver.googleapis.com/batch/resourceMetadata",
             config.MetadataIngestionEndpointFormat());
   EXPECT_EQ(8*1024*1024, config.MetadataIngestionRequestSizeLimitBytes());
   EXPECT_EQ(1000, config.MetadataIngestionRequestSizeLimitCount());

--- a/test/kubernetes_unittest.cc
+++ b/test/kubernetes_unittest.cc
@@ -45,22 +45,21 @@ class KubernetesTest : public ::testing::Test {
 
 TEST_F(KubernetesTest, GetNodeMetadata) {
   Configuration config(std::istringstream(
+    "ProjectId: TestProjectId\n"
     "KubernetesClusterName: TestClusterName\n"
     "KubernetesClusterLocation: TestClusterLocation\n"
-    "InstanceResourceType: gce_instance\n"
-    "InstanceZone: TestZone\n"
-    "InstanceId: TestID\n"
   ));
   Environment environment(config);
   KubernetesReader reader(config, nullptr);  // Don't need HealthChecker.
   json::value node = json::object({
+    {"apiVersion", json::string("NodeVersion")},
     {"metadata", json::object({
       {"name", json::string("testname")},
       {"creationTimestamp", json::string("2018-03-03T01:23:45.678901234Z")},
     })}
   });
-  const auto m =
-      GetNodeMetadata(reader, node->As<json::Object>(), Timestamp(), false);
+  const auto m = GetNodeMetadata(reader, node->As<json::Object>(),
+                                 Timestamp(), false);
   EXPECT_EQ(1, m.ids().size());
   EXPECT_EQ("k8s_node.testname", m.ids()[0]);
   EXPECT_EQ(MonitoredResource("k8s_node", {
@@ -68,23 +67,23 @@ TEST_F(KubernetesTest, GetNodeMetadata) {
     {"node_name", "testname"},
     {"location", "TestClusterLocation"},
   }), m.resource());
-  EXPECT_EQ("", m.metadata().name);
-  EXPECT_EQ("", m.metadata().version);
+  EXPECT_EQ("//container.googleapis.com/projects/TestProjectId/locations/"
+           "TestClusterLocation/clusters/TestClusterName/k8s/nodes/testname",
+           m.metadata().name);
+  EXPECT_EQ("NodeVersion", m.metadata().version);
+  EXPECT_EQ("io.k8s.Node", m.metadata().type);
+  EXPECT_EQ("TestClusterLocation", m.metadata().location);
+  EXPECT_EQ(
+    "//container.googleapis.com/resourceTypes/io.k8s.Node/versions/NodeVersion",
+    m.metadata().schema_name);
   EXPECT_FALSE(m.metadata().is_deleted);
   EXPECT_EQ(Timestamp(), m.metadata().collected_at);
-  json::value expected_metadata = json::object({
-    {"blobs", json::object({
-      {"api", json::object({
-        {"version", json::string("1.6")},  // Hard-coded in kubernetes.cc.
-        {"raw", std::move(node)},
-      })},
-    })},
-  });
-  EXPECT_EQ(expected_metadata->ToString(), m.metadata().metadata->ToString());
+  EXPECT_EQ(node->ToString(), m.metadata().metadata->ToString());
 }
 
 TEST_F(KubernetesTest, GetPodMetadata) {
   Configuration config(std::stringstream(
+    "ProjectId: TestProjectId\n"
     "KubernetesClusterName: TestClusterName\n"
     "KubernetesClusterLocation: TestClusterLocation\n"
     "MetadataApiResourceTypeSeparator: \".\"\n"
@@ -93,6 +92,7 @@ TEST_F(KubernetesTest, GetPodMetadata) {
   KubernetesReader reader(config, nullptr);  // Don't need HealthChecker.
 
   json::value pod = json::object({
+    {"apiVersion", json::string("PodVersion")},
     {"metadata", json::object({
       {"namespace", json::string("TestNamespace")},
       {"name", json::string("TestName")},
@@ -111,28 +111,20 @@ TEST_F(KubernetesTest, GetPodMetadata) {
     {"location", "TestClusterLocation"},
     {"namespace_name", "TestNamespace"},
   }), m.resource());
-  EXPECT_EQ("", m.metadata().name);
-  EXPECT_EQ("", m.metadata().version);
+  EXPECT_EQ("//container.googleapis.com/projects/TestProjectId/locations/"
+            "TestClusterLocation/clusters/TestClusterName/k8s/namespaces/"
+            "TestNamespace/pods/TestName",
+            m.metadata().name);
+  EXPECT_EQ("PodVersion", m.metadata().version);
+  EXPECT_EQ("io.k8s.Pod", m.metadata().type);
+  EXPECT_EQ("TestClusterLocation", m.metadata().location);
+  EXPECT_EQ(
+    "//container.googleapis.com/resourceTypes/io.k8s.Pod/versions/PodVersion",
+    m.metadata().schema_name);
   EXPECT_FALSE(m.metadata().is_deleted);
   EXPECT_EQ(Timestamp(), m.metadata().collected_at);
   EXPECT_FALSE(m.metadata().ignore);
-  json::value expected_metadata = json::object({
-    {"blobs", json::object({
-      {"api", json::object({
-        {"raw", json::object({
-          {"metadata", json::object({
-            {"creationTimestamp",
-              json::string("2018-03-03T01:23:45.678901234Z")},
-            {"name", json::string("TestName")},
-            {"namespace", json::string("TestNamespace")},
-            {"uid", json::string("TestUid")},
-          })},
-        })},
-        {"version", json::string("1.6")},
-      })},
-    })},
-  });
-  EXPECT_EQ(expected_metadata->ToString(), m.metadata().metadata->ToString());
+  EXPECT_EQ(pod->ToString(), m.metadata().metadata->ToString());
 }
 
 TEST_F(KubernetesTest, GetLegacyResource) {
@@ -224,6 +216,7 @@ TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
   KubernetesReader reader(config, nullptr);  // Don't need HealthChecker.
 
   json::value pod = json::object({
+    {"apiVersion", json::string("PodVersion")},
     {"metadata", json::object({
       {"name", json::string("TestPodName")},
       {"namespace", json::string("TestNamespace")},
@@ -291,35 +284,7 @@ TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
   EXPECT_EQ("", m[2].metadata().version);
   EXPECT_FALSE(m[2].metadata().is_deleted);
   EXPECT_EQ(Timestamp(), m[2].metadata().collected_at);
-  json::value pod_metadata = json::object({
-    {"blobs", json::object({
-      {"api", json::object({
-        {"raw", json::object({
-          {"metadata", json::object({
-            {"creationTimestamp",
-              json::string("2018-03-03T01:23:45.678901234Z")},
-            {"name", json::string("TestPodName")},
-            {"namespace", json::string("TestNamespace")},
-            {"uid", json::string("TestPodUid")},
-          })},
-          {"spec", json::object({
-            {"containers", json::array({
-              json::object({{"name", json::string("TestContainerName0")}})
-            })},
-            {"nodeName", json::string("TestSpecNodeName")},
-          })},
-          {"status", json::object({
-            {"containerID", json::string("docker://TestContainerID")},
-            {"containerStatuses", json::array({
-              json::object({{"name", json::string("TestContainerName0")}})
-            })},
-          })},
-        })},
-        {"version", json::string("1.6")},
-      })},
-    })},
-  });
-  EXPECT_EQ(pod_metadata->ToString(),
+  EXPECT_EQ(pod->ToString(),
             m[2].metadata().metadata->ToString());
 }
 }  // namespace google

--- a/test/kubernetes_unittest.cc
+++ b/test/kubernetes_unittest.cc
@@ -58,8 +58,8 @@ TEST_F(KubernetesTest, GetNodeMetadata) {
       {"creationTimestamp", json::string("2018-03-03T01:23:45.678901234Z")},
     })}
   });
-  const auto m = GetNodeMetadata(reader, node->As<json::Object>(),
-                                 Timestamp(), false);
+  const auto m =
+      GetNodeMetadata(reader, node->As<json::Object>(), Timestamp(), false);
   EXPECT_EQ(1, m.ids().size());
   EXPECT_EQ("k8s_node.testname", m.ids()[0]);
   EXPECT_EQ(MonitoredResource("k8s_node", {
@@ -68,8 +68,8 @@ TEST_F(KubernetesTest, GetNodeMetadata) {
     {"location", "TestClusterLocation"},
   }), m.resource());
   EXPECT_EQ("//container.googleapis.com/projects/TestProjectId/locations/"
-           "TestClusterLocation/clusters/TestClusterName/k8s/nodes/testname",
-           m.metadata().name);
+            "TestClusterLocation/clusters/TestClusterName/k8s/nodes/testname",
+            m.metadata().name);
   EXPECT_EQ("NodeVersion", m.metadata().version);
   EXPECT_EQ("io.k8s.Node", m.metadata().type);
   EXPECT_EQ("TestClusterLocation", m.metadata().location);
@@ -284,7 +284,6 @@ TEST_F(KubernetesTest, GetPodAndContainerMetadata) {
   EXPECT_EQ("", m[2].metadata().version);
   EXPECT_FALSE(m[2].metadata().is_deleted);
   EXPECT_EQ(Timestamp(), m[2].metadata().collected_at);
-  EXPECT_EQ(pod->ToString(),
-            m[2].metadata().metadata->ToString());
+  EXPECT_EQ(pod->ToString(), m[2].metadata().metadata->ToString());
 }
 }  // namespace google


### PR DESCRIPTION
Support writing node and pod metadata to the v1beta3 endpoint. With this change, the code in the v1beta3 branch can be run without errors.