### PR TITLE
Don't update owners cache until the value is available.

### DIFF
--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -955,8 +955,8 @@ json::value KubernetesReader::GetOwner(
       throw QueryException("Owner " + kind + " " + name + " (id " + uid +
                            ") disappeared");
     }
-    owners_.emplace(encoded_ref, owner->Clone());
-    return std::move(owner);
+    auto inserted = owners_.emplace(encoded_ref, std::move(owner));
+    found = inserted.first;
   }
   return found->second->Clone();
 }

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -933,39 +933,32 @@ json::value KubernetesReader::GetOwner(
       std::vector<std::string>{api_version, kind, uid}, "/");
 
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  auto found = owners_.emplace(std::piecewise_construct,
-                               std::forward_as_tuple(encoded_ref),
-                               std::forward_as_tuple());
-  json::value& owner = found.first->second;
-  if (found.second) {  // Not found, inserted new.
+  auto found = owners_.find(encoded_ref);
+  if (found == owners_.end()) {  // Not found, add new.
     const auto path_component = KindPath(api_version, kind);
 #ifdef VERBOSE
     LOG(DEBUG) << "KindPath returned {" << path_component.first << ", "
                << path_component.second << "}";
 #endif
-    try {
-      owner = std::move(
-          QueryMaster(path_component.first + "/namespaces/" + ns + "/" +
-                      path_component.second + "/" + name));
-      // Sanity check: because we are looking up by name, the object we get
-      // back might have a different uid.
-      const json::Object* owner_obj = owner->As<json::Object>();
-      const json::Object* metadata = owner_obj->Get<json::Object>("metadata");
-      const std::string owner_uid = metadata->Get<json::String>("uid");
-      if (owner_uid != uid) {
-        LOG(WARNING) << "Owner " << kind << "'" << name << "' (id " << uid
-                     << ") disappeared before we could query it. Found id "
-                     << owner_uid << " instead.";
-        owner.reset();
-        throw QueryException("Owner " + kind + " " + name + " (id " + uid +
-                             ") disappeared");
-      }
-    } catch (const QueryException& e) {
-      owners_.erase(encoded_ref);  // Remove the nullptr entry from owners_.
-      throw;
+    json::value owner =
+        QueryMaster(path_component.first + "/namespaces/" + ns + "/" +
+                    path_component.second + "/" + name);
+    // Sanity check: because we are looking up by name, the object we get
+    // back might have a different uid.
+    const json::Object* owner_obj = owner->As<json::Object>();
+    const json::Object* metadata = owner_obj->Get<json::Object>("metadata");
+    const std::string owner_uid = metadata->Get<json::String>("uid");
+    if (owner_uid != uid) {
+      LOG(WARNING) << "Owner " << kind << "'" << name << "' (id " << uid
+                   << ") disappeared before we could query it. Found id "
+                   << owner_uid << " instead.";
+      throw QueryException("Owner " + kind + " " + name + " (id " + uid +
+                           ") disappeared");
     }
+    owners_.emplace(encoded_ref, owner->Clone());
+    return std::move(owner);
   }
-  return owner->Clone();
+  return found->second->Clone();
 }
 
 json::value KubernetesReader::FindTopLevelController(

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -933,8 +933,8 @@ json::value KubernetesReader::GetOwner(
       std::vector<std::string>{api_version, kind, uid}, "/");
 
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  auto found = owners_.find(encoded_ref);
-  if (found == owners_.end()) {  // Not found, add new.
+  auto owner_it = owners_.find(encoded_ref);
+  if (owner_it == owners_.end()) {  // Not found, add new.
     const auto path_component = KindPath(api_version, kind);
 #ifdef VERBOSE
     LOG(DEBUG) << "KindPath returned {" << path_component.first << ", "
@@ -956,9 +956,9 @@ json::value KubernetesReader::GetOwner(
                            ") disappeared");
     }
     auto inserted = owners_.emplace(encoded_ref, std::move(owner));
-    found = inserted.first;
+    owner_it = inserted.first;
   }
-  return found->second->Clone();
+  return owner_it->second->Clone();
 }
 
 json::value KubernetesReader::FindTopLevelController(


### PR DESCRIPTION
Fixes a segfault in `GetOwner`.