### PR TITLE
Make an exact copy of the single entry for the batch request.

### DIFF
--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -98,7 +98,8 @@ void SendMetadataRequest(std::vector<json::value>&& entries,
 
   if (entries.size() == 1) {
     // A single request cannot be sent to the batch endpoint. In order to work
-    // around this, we add a copy of this request.
+    // around this, we add a copy of this request. We're making use of the fact
+    // that sending two identical requests is idempotent.
     entries.emplace_back(entries[0]->Clone());
   }
   const std::string content_type =

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -97,18 +97,9 @@ void SendMetadataRequest(std::vector<json::value>&& entries,
     throw (boost::system::system_error) {
 
   if (entries.size() == 1) {
-    // Add a copy of the single entry, except for the `views` field. This allows
-    // us to sent a request to the batch endpoint when we have a single request.
-    // We're making use of the fact that duplicate metadata is ignored.
-    const json::Object* single_request = entries[0]->As<json::Object>();
-    json::value duplicate_request = json::object({  // ResourceMetadata
-      {"name", single_request->at("name")->Clone()},
-      {"type", single_request->at("type")->Clone()},
-      {"location", single_request->at("location")->Clone()},
-      {"state", single_request->at("state")->Clone()},
-      {"evenTime", single_request->at("evenTime")->Clone()},
-    });
-    entries.emplace_back(std::move(duplicate_request));
+    // Add a copy of the single entry. This allows us to sent a request to the
+    // batch endpoint when we have a single request.
+    entries.emplace_back(entries[0]->Clone());
   }
   const std::string content_type =
       std::string("multipart/mixed; boundary=") + kMultipartBoundary;

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -97,8 +97,8 @@ void SendMetadataRequest(std::vector<json::value>&& entries,
     throw (boost::system::system_error) {
 
   if (entries.size() == 1) {
-    // Add a copy of the single entry. This allows us to sent a request to the
-    // batch endpoint when we have a single request.
+    // A single request cannot be sent to the batch endpoint. In order to work
+    // around this, we add a copy of this request.
     entries.emplace_back(entries[0]->Clone());
   }
   const std::string content_type =


### PR DESCRIPTION
The API will arbitrarily accept one of the requests, so we need to send the views field as well in the duplicate request