### PR TITLE
Switch to using project IDs (instead of project number)

### DIFF
--- a/src/environment.cc
+++ b/src/environment.cc
@@ -122,11 +122,33 @@ const std::string& Environment::ProjectId() const {
     if (!config_.ProjectId().empty()) {
       project_id_ = config_.ProjectId();
     } else {
-      if (config_.VerboseLogging()) {
-        LOG(INFO) << "Getting project id from metadata server";
+      // Extract from credentials.
+      ReadApplicationDefaultCredentials();
+      if (!credentials_project_id_.empty()) {
+        project_id_ = credentials_project_id_;
+      } else if (!client_email_.empty()) {
+        // New-style emails (string@project.iam.gserviceaccount.com).
+        std::string::size_type new_style =
+            client_email_.find(".iam.gserviceaccount.com");
+        if (new_style != std::string::npos) {
+          std::string::size_type at = client_email_.find('@');
+          if (at != std::string::npos) {
+            project_id_ = client_email_.substr(at + 1, new_style - at - 1);
+            LOG(INFO) << "Found project id in credentials: " << project_id_;
+          }
+        } else {
+          LOG(ERROR) << "Unable to extract project id from " << client_email_;
+        }
       }
-      project_id_ = GetMetadataString("project/project-id");
-      LOG(INFO) << "Got project id from metadata server: " << project_id_;
+      if (project_id_.empty()) {
+        // Query the metadata server.
+        // TODO: Other sources.
+        if (config_.VerboseLogging()) {
+          LOG(INFO) << "Getting project id from metadata server";
+        }
+        project_id_ = GetMetadataString("project/project-id");
+        LOG(INFO) << "Got project id from metadata server: " << project_id_;
+      }
     }
   }
   return project_id_;
@@ -244,6 +266,9 @@ void Environment::ReadApplicationDefaultCredentials() const {
 
     client_email_ = creds->Get<json::String>("client_email");
     private_key_ = creds->Get<json::String>("private_key");
+    if (creds->Has("project_id")) {
+      credentials_project_id_ = creds->Get<json::String>("project_id");
+    }
 
     LOG(INFO) << "Retrieved private key from application default credentials";
   } catch (const json::Exception& e) {

--- a/src/environment.h
+++ b/src/environment.h
@@ -28,7 +28,7 @@ class Environment {
  public:
   Environment(const Configuration& config);
 
-  const std::string& NumericProjectId() const;
+  const std::string& ProjectId() const;
   const std::string& InstanceResourceType() const;
   const std::string& InstanceId() const;
   const std::string& InstanceZone() const;

--- a/src/environment.h
+++ b/src/environment.h
@@ -67,6 +67,7 @@ class Environment {
   mutable std::string kubernetes_cluster_location_;
   mutable std::string client_email_;
   mutable std::string private_key_;
+  mutable std::string credentials_project_id_;
   mutable std::string metadata_server_url_;
   mutable bool application_default_credentials_read_;
 };

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -566,7 +566,7 @@ json::value KubernetesReader::QueryMaster(const std::string& path) const
 }
 
 const std::string KubernetesReader::ClusterFullName() const {
-  const std::string project_id = environment_.NumericProjectId();
+  const std::string project_id = environment_.ProjectId();
   const std::string cluster_name = environment_.KubernetesClusterName();
   const std::string location = environment_.KubernetesClusterLocation();
   const std::string location_type =

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -182,7 +182,7 @@ void MetadataReporter::SendMetadata(
   if (config_.VerboseLogging()) {
     LOG(INFO) << "Sending request to the server";
   }
-  const std::string project_id = environment_.NumericProjectId();
+  const std::string project_id = environment_.ProjectId();
   const std::string& endpoint = config_.MetadataIngestionEndpointFormat();
   const std::string& publish_path =
       format::Substitute(kPublishPathFormat, {{"project_id", project_id}});

--- a/test/environment_unittest.cc
+++ b/test/environment_unittest.cc
@@ -62,30 +62,6 @@ TEST_F(EnvironmentTest, ValuesFromConfig) {
             environment.KubernetesClusterName());
 }
 
-TEST_F(EnvironmentTest, NumericProjectIdFromConfigNewStyleCredentials) {
-  testing::TemporaryFile credentials_file(
-    std::string(test_info_->name()) + "_creds.json",
-    "{\"client_email\":\"user@12345.iam.gserviceaccount.com\","
-    "\"private_key\":\"some_key\"}");
-  Configuration config(std::istringstream(
-      "CredentialsFile: '" + credentials_file.FullPath().native() + "'\n"
-  ));
-  Environment environment(config);
-  EXPECT_EQ("12345", environment.NumericProjectId());
-}
-
-TEST_F(EnvironmentTest, NumericProjectIdFromConfigOldStyleCredentials) {
-  testing::TemporaryFile credentials_file(
-    std::string(test_info_->name()) + "_creds.json",
-    "{\"client_email\":\"12345-hash@developer.gserviceaccount.com\","
-    "\"private_key\":\"some_key\"}");
-  Configuration config(std::istringstream(
-      "CredentialsFile: '" + credentials_file.FullPath().native() + "'\n"
-  ));
-  Environment environment(config);
-  EXPECT_EQ("12345", environment.NumericProjectId());
-}
-
 TEST_F(EnvironmentTest, ReadApplicationDefaultCredentialsSucceeds) {
   testing::TemporaryFile credentials_file(
     std::string(test_info_->name()) + "_creds.json",
@@ -152,6 +128,7 @@ TEST_F(EnvironmentTest, ValuesFromMetadataServer) {
   server.SetResponse("/instance/zone",
                      "projects/some-project/zones/some-instance-zone");
   server.SetResponse("/project/numeric-project-id", "12345");
+  server.SetResponse("/project/project-id", "my-project");
 
   Configuration config;
   Environment environment(config);
@@ -161,7 +138,7 @@ TEST_F(EnvironmentTest, ValuesFromMetadataServer) {
   EXPECT_EQ("some-cluster-name", environment.KubernetesClusterName());
   EXPECT_EQ("some-instance-id", environment.InstanceId());
   EXPECT_EQ("some-instance-zone", environment.InstanceZone());
-  EXPECT_EQ("12345", environment.NumericProjectId());
+  EXPECT_EQ("my-project", environment.ProjectId());
 }
 
 TEST_F(EnvironmentTest, KubernetesClusterLocationFromMetadataServerKubeEnv) {

--- a/test/environment_unittest.cc
+++ b/test/environment_unittest.cc
@@ -62,6 +62,42 @@ TEST_F(EnvironmentTest, ValuesFromConfig) {
             environment.KubernetesClusterName());
 }
 
+TEST_F(EnvironmentTest, ProjectIdFromConfigNewStyleCredentialsProjectId) {
+  testing::TemporaryFile credentials_file(
+    std::string(test_info_->name()) + "_creds.json",
+    "{\"client_email\":\"user@email-project.iam.gserviceaccount.com\","
+    "\"private_key\":\"some_key\",\"project_id\":\"my-project\"}");
+  Configuration config(std::istringstream(
+      "CredentialsFile: '" + credentials_file.FullPath().native() + "'\n"
+  ));
+  Environment environment(config);
+  EXPECT_EQ("my-project", environment.ProjectId());
+}
+
+TEST_F(EnvironmentTest, ProjectIdFromConfigNewStyleCredentialsEmail) {
+  testing::TemporaryFile credentials_file(
+    std::string(test_info_->name()) + "_creds.json",
+    "{\"client_email\":\"user@my-project.iam.gserviceaccount.com\","
+    "\"private_key\":\"some_key\"}");
+  Configuration config(std::istringstream(
+      "CredentialsFile: '" + credentials_file.FullPath().native() + "'\n"
+  ));
+  Environment environment(config);
+  EXPECT_EQ("my-project", environment.ProjectId());
+}
+
+TEST_F(EnvironmentTest, ProjectIdFromConfigOldStyleCredentialsEmailFails) {
+  testing::TemporaryFile credentials_file(
+    std::string(test_info_->name()) + "_creds.json",
+    "{\"client_email\":\"12345-hash@developer.gserviceaccount.com\","
+    "\"private_key\":\"some_key\"}");
+  Configuration config(std::istringstream(
+      "CredentialsFile: '" + credentials_file.FullPath().native() + "'\n"
+  ));
+  Environment environment(config);
+  EXPECT_EQ("", environment.ProjectId());
+}
+
 TEST_F(EnvironmentTest, ReadApplicationDefaultCredentialsSucceeds) {
   testing::TemporaryFile credentials_file(
     std::string(test_info_->name()) + "_creds.json",


### PR DESCRIPTION
The metadata API expects project IDs in the resource names.