### PR TITLE
Switch to using project IDs, instead of project number

### DIFF
--- a/src/environment.cc
+++ b/src/environment.cc
@@ -105,31 +105,24 @@ std::string Environment::GetMetadataString(const std::string& path) const {
   }
 }
 
-const std::string& Environment::NumericProjectId() const {
+const std::string& Environment::ProjectId() const {
   std::lock_guard<std::mutex> lock(mutex_);
   if (project_id_.empty()) {
     if (!config_.ProjectId().empty()) {
       project_id_ = config_.ProjectId();
     } else {
+      // Extract from credentials.
       ReadApplicationDefaultCredentials();
-      if (!client_email_.empty()) {
-        // Extract from credentials.
+      if (!credentials_project_id_.empty()) {
+        project_id_ = credentials_project_id_;
+      } else if (!client_email_.empty()) {
         // New-style emails (string@project.iam.gserviceaccount.com).
-        // Old-style emails (projectnumber-hash@developer.gserviceaccount.com).
         std::string::size_type new_style =
             client_email_.find(".iam.gserviceaccount.com");
-        std::string::size_type old_style =
-            client_email_.find("@developer.gserviceaccount.com");
         if (new_style != std::string::npos) {
           std::string::size_type at = client_email_.find('@');
           if (at != std::string::npos) {
             project_id_ = client_email_.substr(at + 1, new_style - at - 1);
-            LOG(INFO) << "Found project id in credentials: " << project_id_;
-          }
-        } else if (old_style != std::string::npos) {
-          std::string::size_type dash = client_email_.find('-');
-          if (dash != std::string::npos) {
-            project_id_ = client_email_.substr(0, dash);
             LOG(INFO) << "Found project id in credentials: " << project_id_;
           }
         } else {
@@ -142,7 +135,7 @@ const std::string& Environment::NumericProjectId() const {
         if (config_.VerboseLogging()) {
           LOG(INFO) << "Getting project id from metadata server";
         }
-        project_id_ = GetMetadataString("project/numeric-project-id");
+        project_id_ = GetMetadataString("project/project-id");
         LOG(INFO) << "Got project id from metadata server: " << project_id_;
       }
     }
@@ -262,6 +255,9 @@ void Environment::ReadApplicationDefaultCredentials() const {
 
     client_email_ = creds->Get<json::String>("client_email");
     private_key_ = creds->Get<json::String>("private_key");
+    if (creds->Has("project_id")) {
+      credentials_project_id_ = creds->Get<json::String>("project_id");
+    }
 
     LOG(INFO) << "Retrieved private key from application default credentials";
   } catch (const json::Exception& e) {

--- a/src/environment.h
+++ b/src/environment.h
@@ -32,7 +32,7 @@ class Environment {
  public:
   Environment(const Configuration& config);
 
-  const std::string& NumericProjectId() const;
+  const std::string& ProjectId() const;
   const std::string& InstanceResourceType() const;
   const std::string& InstanceId() const;
   const std::string& InstanceZone() const;
@@ -70,6 +70,7 @@ class Environment {
   mutable std::string kubernetes_cluster_location_;
   mutable std::string client_email_;
   mutable std::string private_key_;
+  mutable std::string credentials_project_id_;
   mutable std::string metadata_server_url_;
   mutable bool application_default_credentials_read_;
 };

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -124,7 +124,7 @@ void MetadataReporter::SendMetadata(
   if (config_.VerboseLogging()) {
     LOG(INFO) << "Sending request to the server";
   }
-  const std::string project_id = environment_.NumericProjectId();
+  const std::string project_id = environment_.ProjectId();
   // The endpoint template is expected to be of the form
   // "https://stackdriver.googleapis.com/.../projects/{{project_id}}/...".
   const std::string endpoint =

--- a/test/environment_unittest.cc
+++ b/test/environment_unittest.cc
@@ -83,6 +83,7 @@ TEST_F(EnvironmentTest, ProjectIdFromConfigNewStyleCredentialsEmail) {
 }
 
 TEST_F(EnvironmentTest, ProjectIdFromConfigOldStyleCredentialsEmailFails) {
+  testing::FakeServer server;
   testing::TemporaryFile credentials_file(
     std::string(test_info_->name()) + "_creds.json",
     "{\"client_email\":\"12345-hash@developer.gserviceaccount.com\","
@@ -91,6 +92,8 @@ TEST_F(EnvironmentTest, ProjectIdFromConfigOldStyleCredentialsEmailFails) {
       "CredentialsFile: '" + credentials_file.FullPath().native() + "'\n"
   ));
   Environment environment(config);
+  testing::EnvironmentUtil::SetMetadataServerUrlForTest(
+      &environment, server.GetUrl() + "/");
   EXPECT_EQ("", environment.ProjectId());
 }
 


### PR DESCRIPTION
The metadata API expects project IDs in the resource names.