### PR TITLE
Switch health checker tests to the new interfaces.

### DIFF
--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -127,9 +127,6 @@ Configuration::Configuration()
          option(kubernetes_service_metadata_, true)},
         {"InstanceId", option(instance_id_, "")},
         {"InstanceZone", option(instance_zone_, "")},
-        {"HealthCheckFile",
-         option(health_check_file_,
-                "/var/run/metadata-agent/health/unhealthy")},
         {"HealthCheckMaxDataAgeSeconds",
          option(health_check_max_data_age_seconds_, 5*60)},
       })) {}

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -168,10 +168,6 @@ class Configuration {
     return instance_zone_;
   }
 
-  const std::string& HealthCheckFile() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return health_check_file_;
-  }
   int HealthCheckMaxDataAgeSeconds() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return health_check_max_data_age_seconds_;
@@ -225,7 +221,6 @@ class Configuration {
   bool kubernetes_service_metadata_;
   std::string instance_id_;
   std::string instance_zone_;
-  std::string health_check_file_;
   int health_check_max_data_age_seconds_;
 
   std::unique_ptr<const OptionMap> options_;

--- a/src/health_checker.cc
+++ b/src/health_checker.cc
@@ -27,27 +27,11 @@ namespace google {
 
 HealthChecker::HealthChecker(const Configuration& config,
                              const MetadataStore& store)
-    : config_(config), store_(store) {
-  boost::filesystem::create_directories(
-      boost::filesystem::path(config_.HealthCheckFile()).parent_path());
-  std::remove(config_.HealthCheckFile().c_str());
-}
+    : config_(config), store_(store) {}
 
 void HealthChecker::SetUnhealthy(const std::string& component) {
   std::lock_guard<std::mutex> lock(mutex_);
   unhealthy_components_.insert(component);
-  std::ofstream health_file(config_.HealthCheckFile());
-  health_file << std::endl;
-}
-
-bool HealthChecker::IsHealthy() const {
-  std::lock_guard<std::mutex> lock(mutex_);
-  return unhealthy_components_.empty();
-}
-
-void HealthChecker::CleanupForTest() {
-  boost::filesystem::remove_all(boost::filesystem::path(
-      config_.HealthCheckFile()).parent_path());
 }
 
 std::set<std::string> HealthChecker::UnhealthyComponents() const {

--- a/src/health_checker.h
+++ b/src/health_checker.h
@@ -38,9 +38,6 @@ class HealthChecker {
  private:
   friend class HealthCheckerUnittest;
 
-  bool IsHealthy() const;
-  void CleanupForTest();
-
   const Configuration& config_;
   const MetadataStore& store_;
   std::set<std::string> unhealthy_components_;

--- a/test/configuration_unittest.cc
+++ b/test/configuration_unittest.cc
@@ -38,7 +38,6 @@ void VerifyDefaultConfig(const Configuration& config) {
   EXPECT_EQ(true, config.KubernetesServiceMetadata());
   EXPECT_EQ("", config.InstanceId());
   EXPECT_EQ("", config.InstanceZone());
-  EXPECT_EQ("/var/run/metadata-agent/health/unhealthy", config.HealthCheckFile());
 }
 
 TEST(ConfigurationTest, NoConfig) {
@@ -57,14 +56,12 @@ TEST(ConfigurationTest, PopulatedConfig) {
       "MetadataApiNumThreads: 13\n"
       "MetadataReporterPurgeDeleted: true\n"
       "MetadataReporterUserAgent: \"foobar/foobaz\"\n"
-      "HealthCheckFile: /a/b/c\n"
       "MetadataIngestionRequestSizeLimitCount: 500\n"
   ));
   EXPECT_EQ("TestProjectId", config.ProjectId());
   EXPECT_EQ(13, config.MetadataApiNumThreads());
   EXPECT_EQ(true, config.MetadataReporterPurgeDeleted());
   EXPECT_EQ("foobar/foobaz", config.MetadataReporterUserAgent());
-  EXPECT_EQ("/a/b/c", config.HealthCheckFile());
   EXPECT_EQ(500, config.MetadataIngestionRequestSizeLimitCount());
 }
 

--- a/test/health_checker_unittest.cc
+++ b/test/health_checker_unittest.cc
@@ -2,72 +2,69 @@
 #include "../src/store.h"
 #include "gtest/gtest.h"
 #include <sstream>
-#include <boost/filesystem.hpp>
 
 
 namespace google {
 
 class HealthCheckerUnittest : public ::testing::Test {
  protected:
-  static void Cleanup(HealthChecker* health_checker){
-    health_checker->CleanupForTest();
-  }
-
   static void SetUnhealthy(HealthChecker* health_checker,
                            const std::string& state_name) {
     health_checker->SetUnhealthy(state_name);
   }
-
-  static bool IsHealthy(const HealthChecker& health_checker) {
-    return health_checker.IsHealthy();
-  }
-
 };
 
-namespace {
-std::istringstream IsolationPathConfig(const std::string& test_name) {
-  return std::istringstream("HealthCheckFile: './" + test_name + "/unhealthy'");
-}
-}  // namespace
-
 TEST_F(HealthCheckerUnittest, DefaultHealthy) {
-  Configuration config(IsolationPathConfig(test_info_->name()));
+  Configuration config;
   MetadataStore store(config);
   HealthChecker health_checker(config, store);
-  EXPECT_TRUE(IsHealthy(health_checker));
-  Cleanup(&health_checker);
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
 }
 
 TEST_F(HealthCheckerUnittest, SimpleFailure) {
-  Configuration config(IsolationPathConfig(test_info_->name()));
+  Configuration config;
   MetadataStore store(config);
   HealthChecker health_checker(config, store);
   SetUnhealthy(&health_checker, "kubernetes_pod_thread");
-  EXPECT_FALSE(IsHealthy(health_checker));
-  Cleanup(&health_checker);
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "kubernetes_pod_thread",
+            }));
 }
 
 TEST_F(HealthCheckerUnittest, MultiFailure) {
-  Configuration config(IsolationPathConfig(test_info_->name()));
+  Configuration config;
   MetadataStore store(config);
   HealthChecker health_checker(config, store);
-  EXPECT_TRUE(IsHealthy(health_checker));
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
   SetUnhealthy(&health_checker, "kubernetes_pod_thread");
-  EXPECT_FALSE(IsHealthy(health_checker));
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "kubernetes_pod_thread",
+            }));
   SetUnhealthy(&health_checker, "kubernetes_node_thread");
-  EXPECT_FALSE(IsHealthy(health_checker));
-  Cleanup(&health_checker);
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "kubernetes_pod_thread",
+                "kubernetes_node_thread",
+            }));
 }
 
 TEST_F(HealthCheckerUnittest, FailurePersists) {
-  Configuration config(IsolationPathConfig(test_info_->name()));
+  Configuration config;
   MetadataStore store(config);
   HealthChecker health_checker(config, store);
-  EXPECT_TRUE(IsHealthy(health_checker));
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
   SetUnhealthy(&health_checker, "kubernetes_pod_thread");
-  EXPECT_FALSE(IsHealthy(health_checker));
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "kubernetes_pod_thread",
+            }));
   SetUnhealthy(&health_checker, "kubernetes_pod_thread");
-  EXPECT_FALSE(IsHealthy(health_checker));
-  Cleanup(&health_checker);
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "kubernetes_pod_thread",
+            }));
 }
+
 }  // namespace google

--- a/test/health_checker_unittest.cc
+++ b/test/health_checker_unittest.cc
@@ -1,5 +1,6 @@
 #include "../src/health_checker.h"
 #include "../src/store.h"
+#include "../src/time.h"
 #include "gtest/gtest.h"
 #include <sstream>
 
@@ -65,6 +66,62 @@ TEST_F(HealthCheckerUnittest, FailurePersists) {
             std::set<std::string>({
                 "kubernetes_pod_thread",
             }));
+}
+
+TEST_F(HealthCheckerUnittest, RecentMetadataSucceeds) {
+  Configuration config(std::istringstream(
+      "HealthCheckMaxDataAgeSeconds: 20"
+  ));
+  MetadataStore store(config);
+  HealthChecker health_checker(config, store);
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
+  time_point now = std::chrono::system_clock::now();
+  time_point then = now - std::chrono::seconds(10);
+  store.UpdateMetadata(
+      MonitoredResource("my_resource", {}),
+      MetadataStore::Metadata("0", false, then, then, json::object({})));
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
+}
+
+TEST_F(HealthCheckerUnittest, StaleMetadataCausesFailure) {
+  Configuration config(std::istringstream(
+      "HealthCheckMaxDataAgeSeconds: 1"
+  ));
+  MetadataStore store(config);
+  HealthChecker health_checker(config, store);
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
+  time_point now = std::chrono::system_clock::now();
+  time_point then = now - std::chrono::seconds(10);
+  store.UpdateMetadata(
+      MonitoredResource("my_resource", {}),
+      MetadataStore::Metadata("0", false, then, then, json::object({})));
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "my_resource",
+            }));
+}
+
+TEST_F(HealthCheckerUnittest, UpdatedMetadataClearsFailure) {
+  Configuration config(std::istringstream(
+      "HealthCheckMaxDataAgeSeconds: 1"
+  ));
+  MetadataStore store(config);
+  HealthChecker health_checker(config, store);
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
+  time_point now = std::chrono::system_clock::now();
+  time_point then = now - std::chrono::seconds(10);
+  store.UpdateMetadata(
+      MonitoredResource("my_resource", {}),
+      MetadataStore::Metadata("0", false, then, then, json::object({})));
+  EXPECT_EQ(health_checker.UnhealthyComponents(),
+            std::set<std::string>({
+                "my_resource",
+            }));
+  now = std::chrono::system_clock::now();
+  store.UpdateMetadata(
+      MonitoredResource("my_resource", {}),
+      MetadataStore::Metadata("0", false, now, now, json::object({})));
+  EXPECT_TRUE(health_checker.UnhealthyComponents().empty());
 }
 
 }  // namespace google


### PR DESCRIPTION
Remove the last vestiges of file-based health checks.