### PR TITLE
Attempt to reduce flakiness due to fake server port reuse.

### DIFF
--- a/test/fake_http_server.cc
+++ b/test/fake_http_server.cc
@@ -22,7 +22,10 @@ namespace testing {
 FakeServer::FakeServer()
     // Note: An empty port selects a random available port (this behavior
     // is not documented).
-    : server_(Server::options(handler_).address("127.0.0.1").port("")) {
+    : server_(Server::options(handler_)
+                  .address("127.0.0.1")
+                  .port("")
+                  .reuse_address(true)) {
   server_.listen();
   server_thread_ = std::thread([this] { server_.run(); });
 }


### PR DESCRIPTION
Should fix errors like:
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::system::system_error> >'
  what():  non_blocking: Bad file descriptor
Aborted (core dumped)
```