### PR TITLE
Add support for watching and ingesting more Kubernetes resources.

### DIFF
--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -950,23 +950,27 @@ KubernetesUpdater::KubernetesUpdater(const Configuration& config,
         config.KubernetesUpdaterIntervalSeconds(),
         [=]() { return reader_.MetadataQuery(); }) { }
 
-const KubernetesUpdater::WatchId KubernetesUpdater::kClusterLevelObjectTypes[] =
-{
-    {"cronjobs", "batch/v1beta1"},
-    {"daemonsets", "apps/v1"},
-    {"daemonsets", "extensions/v1beta1"},
-    {"deployments", "apps/v1"},
-    {"deployments", "extensions/v1beta1"},
-    {"endpoints", "v1"},
-    {"ingresses", "extensions/v1beta1"},
-    {"jobs", "batch/v1"},
-    {"namespaces", "v1"},
-    {"replicasets", "apps/v1"},
-    {"replicasets", "extensions/v1beta1"},
-    {"replicationcontrollers", "v1"},
-    {"services", "v1"},
-    {"statefulsets", "apps/v1"},
-};
+const std::vector<KubernetesUpdater::WatchId>&
+KubernetesUpdater::ClusterLevelObjectTypes() {
+  static const std::vector<WatchId>* cluster_level_object_types =
+      new std::vector<WatchId>{
+        {"cronjobs", "batch/v1beta1"},
+        {"daemonsets", "apps/v1"},
+        {"daemonsets", "extensions/v1beta1"},
+        {"deployments", "apps/v1"},
+        {"deployments", "extensions/v1beta1"},
+        {"endpoints", "v1"},
+        {"ingresses", "extensions/v1beta1"},
+        {"jobs", "batch/v1"},
+        {"namespaces", "v1"},
+        {"replicasets", "apps/v1"},
+        {"replicasets", "extensions/v1beta1"},
+        {"replicationcontrollers", "v1"},
+        {"services", "v1"},
+        {"statefulsets", "apps/v1"},
+      };
+  return *cluster_level_object_types;
+}
 
 void KubernetesUpdater::ValidateDynamicConfiguration() const
     throw(ConfigurationValidationError) {
@@ -1000,20 +1004,16 @@ void KubernetesUpdater::StartUpdater() {
     auto cb = [=](std::vector<MetadataUpdater::ResourceMetadata>&& results) {
       MetadataCallback(std::move(results));
     };
-    object_watch_threads_.emplace(
-        WatchId("nodes", "v1"),
-        std::thread([=]() {
-          reader_.WatchNodes(watched_node, cb);
-        }));
-    object_watch_threads_.emplace(
-        WatchId("pods", "v1"),
-        std::thread([=]() {
-          reader_.WatchPods(watched_node, cb);
-        }));
+    object_watch_threads_.emplace(WatchId("nodes", "v1"), std::thread([=]() {
+      reader_.WatchNodes(watched_node, cb);
+    }));
+    object_watch_threads_.emplace(WatchId("pods", "v1"), std::thread([=]() {
+      reader_.WatchPods(watched_node, cb);
+    }));
     if (config().KubernetesClusterLevelMetadata()) {
-      for (const auto& watch_id: kClusterLevelObjectTypes) {
-        const std::string plural_kind = watch_id.first;
-        const std::string api_version = watch_id.second;
+      for (const auto& watch_id: ClusterLevelObjectTypes()) {
+        const std::string& plural_kind = watch_id.first;
+        const std::string& api_version = watch_id.second;
         object_watch_threads_.emplace(
             watch_id,
             std::thread([=]() {

--- a/src/kubernetes.cc
+++ b/src/kubernetes.cc
@@ -1014,11 +1014,9 @@ void KubernetesUpdater::StartUpdater() {
       for (const auto& watch_id: ClusterLevelObjectTypes()) {
         const std::string& plural_kind = watch_id.first;
         const std::string& api_version = watch_id.second;
-        object_watch_threads_.emplace(
-            watch_id,
-            std::thread([=]() {
-              reader_.WatchObjects(plural_kind, api_version, cb);
-            }));
+        object_watch_threads_.emplace(watch_id, std::thread([=]() {
+          reader_.WatchObjects(plural_kind, api_version, cb);
+        }));
       }
     }
   } else {

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -202,17 +202,18 @@ class KubernetesUpdater : public PollingMetadataUpdater {
   void NotifyStopUpdater();
 
  private:
+  // WatchId combines the plural Kubernetes kind and API version.
+  using WatchId = std::pair<const char*, const char*>;
+  // List of cluster level objects to watch.
+  static const WatchId kClusterLevelObjectTypes[];
+
   // Metadata watcher callback.
   void MetadataCallback(std::vector<ResourceMetadata>&& result_vector);
 
   KubernetesReader reader_;
   HealthChecker* health_checker_;
-  // WatchId combines the plural kubernetes kind, and API version.
-  using WatchId = std::pair<const char*, const char*>;
   // Map from the watch IDs to the respective threads.
   std::map<WatchId, std::thread> object_watch_threads_;
-  // List of watch IDs.
-  static const WatchId watch_ids_[];
 };
 
 }

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -203,9 +203,9 @@ class KubernetesUpdater : public PollingMetadataUpdater {
 
  private:
   // WatchId combines the plural Kubernetes kind and API version.
-  using WatchId = std::pair<const char*, const char*>;
+  using WatchId = std::pair<std::string, std::string>;
   // List of cluster level objects to watch.
-  static const WatchId kClusterLevelObjectTypes[];
+  static const std::vector<WatchId>& ClusterLevelObjectTypes();
 
   // Metadata watcher callback.
   void MetadataCallback(std::vector<ResourceMetadata>&& result_vector);

--- a/src/kubernetes.h
+++ b/src/kubernetes.h
@@ -186,12 +186,6 @@ class KubernetesUpdater : public PollingMetadataUpdater {
   KubernetesUpdater(const Configuration& config, HealthChecker* health_checker,
                     MetadataStore* store);
   ~KubernetesUpdater() {
-    if (node_watch_thread_.joinable()) {
-      node_watch_thread_.join();
-    }
-    if (pod_watch_thread_.joinable()) {
-      pod_watch_thread_.join();
-    }
     for (auto& thread_it: object_watch_threads_) {
       std::thread& watch_thread = thread_it.second;
       if (watch_thread.joinable()) {
@@ -213,11 +207,12 @@ class KubernetesUpdater : public PollingMetadataUpdater {
 
   KubernetesReader reader_;
   HealthChecker* health_checker_;
-  std::thread node_watch_thread_;
-  std::thread pod_watch_thread_;
-  // Map from plural kind and API version to the thread.
-  std::map<std::pair<std::string, std::string>, std::thread>
-      object_watch_threads_;
+  // WatchId combines the plural kubernetes kind, and API version.
+  using WatchId = std::pair<const char*, const char*>;
+  // Map from the watch IDs to the respective threads.
+  std::map<WatchId, std::thread> object_watch_threads_;
+  // List of watch IDs.
+  static const WatchId watch_ids_[];
 };
 
 }


### PR DESCRIPTION
The threads to watch resources other than Node and Pod are started based on the Kubernetes resource kind and API version provided in a static vector. This works for all resource types that use the generic callback.
