### PR TITLE
Update logging output to match glog

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -37,7 +37,7 @@ Logger::Logger(const char* file, int line, Severity severity, LogStream* stream)
   (*this) << kSeverities_[severity]
           << time_val
           << std::hex << std::this_thread::get_id() << std::dec << " "
-          << file_ << ":" << line_ << " ";
+          << file_ << ":" << line_ << "] ";
 }
 
 Logger::~Logger() {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -34,9 +34,10 @@ Logger::Logger(const char* file, int line, Severity severity, LogStream* stream)
   // GCC 4.x does not implement std::put_time. Sigh.
   char time_val[20];
   std::strftime(time_val, sizeof(time_val), "%m%d %H:%M:%S ", &local_time);
+  std::hash<std::thread::id> hasher;
   (*this) << kSeverities_[severity]
           << time_val
-          << std::hex << std::this_thread::get_id() << std::dec << " "
+          << static_cast<unsigned int>(hasher(std::this_thread::get_id())) << " "
           << file_ << ":" << line_ << "] ";
 }
 

--- a/test/logging_unittest.cc
+++ b/test/logging_unittest.cc
@@ -35,7 +35,7 @@ TEST(LoggingTest, Logger) {
 
   EXPECT_TRUE(boost::regex_match(out.str(), boost::regex(
      "W\\d{4} \\d{2}:\\d{2}:\\d{2} .+ "
-     "somefile.cc:123 Test message\n")));
+     "somefile.cc:123] Test message\n")));
 }
 
 }  // namespace

--- a/test/logging_unittest.cc
+++ b/test/logging_unittest.cc
@@ -34,7 +34,7 @@ TEST(LoggingTest, Logger) {
   }
 
   EXPECT_TRUE(boost::regex_match(out.str(), boost::regex(
-     "W\\d{4} \\d{2}:\\d{2}:\\d{2} .+ "
+     "W\\d{4} \\d{2}:\\d{2}:\\d{2} \\d+ "
      "somefile.cc:123] Test message\n")));
 }
 


### PR DESCRIPTION
glog expects a `] ` before the message text: https://github.com/google/glog/blob/master/src/logging.cc#L1080